### PR TITLE
remove all samples associated with a species from dataset

### DIFF
--- a/src/containers/Downloads/index.js
+++ b/src/containers/Downloads/index.js
@@ -105,7 +105,7 @@ class Download extends Component {
         <Button
           text="Remove"
           buttonStyle="remove"
-          onClick={() => this.props.removedSpecies(speciesName)}
+          onClick={() => this.props.removeSpecies(species[speciesName])}
         />
       </div>
     ));

--- a/src/state/download/reducer.js
+++ b/src/state/download/reducer.js
@@ -47,6 +47,13 @@ export default (state = initialState, action) => {
         dataSet
       };
     }
+    case 'DOWNLOAD_REMOVE_SPECIES_SUCCESS': {
+      const { dataSet } = action.data;
+      return {
+        ...state,
+        dataSet
+      };
+    }
     case 'DOWNLOAD_FETCH_DETAILS': {
       return {
         ...state,


### PR DESCRIPTION
## Issue Number
#20 

**This PR relies on changes from #30**

## Purpose/Implementation Notes
* Fixes the "remove species" functionality that broke after getting dataset data from the `/dataset` endpoint

## Types of changes

What types of changes does your code introduce?
* [x] Bugfix (non-breaking change which fixes an issue)

## Functional tests
* Clicking the "Remove" button on the "Species" view of samples will remove all samples associated with that species from all corresponding experiments

## Screenshots
![issue-20](https://user-images.githubusercontent.com/4724065/40445825-4a6f3122-5e9b-11e8-8cdb-8ad85584479b.gif)

