### PR TITLE
Link to Samples table from search results

### DIFF
--- a/src/components/Anchor/index.js
+++ b/src/components/Anchor/index.js
@@ -25,6 +25,6 @@ export default class Anchor extends React.Component {
   }
 
   render() {
-    return <a ref={x => (this.element = x)} name={this.props.name} />;
+    return <div ref={x => (this.element = x)}>{this.props.children()}</div>;
   }
 }

--- a/src/components/Anchor/index.js
+++ b/src/components/Anchor/index.js
@@ -1,12 +1,6 @@
 import React from 'react';
 
 /**
- * This constant is used to correct the scroll bar position when navigating to an anchor
- * Since we want the target element to appear below the scrollbar
- */
-const TOP_BAR_HEIGHT = 110;
-
-/**
  * Creates an anchor class that scrolls to its possition if the correct hash has been specified
  * Only when the component is loaded
  */
@@ -19,12 +13,24 @@ export default class Anchor extends React.Component {
       setTimeout(() => {
         const offset = this.element.offsetTop;
         // Substract the top bar height from the element's position
-        window.scrollTo({ top: offset - TOP_BAR_HEIGHT });
+        window.scrollTo({ top: offset - this._topBarHeight() });
       }, 0);
     }
   }
 
   render() {
     return <div ref={x => (this.element = x)}>{this.props.children()}</div>;
+  }
+
+  /**
+   * To work properly this component needs to measure the height of the header, to be able to calculate
+   * the correct position of the scrollbar when navigating to an element in the screen.
+   *
+   * This method is probably an anti-pattern in React, since it creates a dependency between this component and
+   * the header component that is in other place. A better solution could take advantage of the React Context API
+   * but that seemed overcomplicated for this use case.
+   */
+  _topBarHeight() {
+    return document.getElementsByClassName('js-header')[0].offsetHeight;
   }
 }

--- a/src/components/Anchor/index.js
+++ b/src/components/Anchor/index.js
@@ -1,0 +1,22 @@
+import React from 'react';
+
+/**
+ * Creates an anchor class that scrolls to its possition if the correct hash has been specified
+ * Only when the component is loaded
+ */
+export default class Anchor extends React.Component {
+  componentDidMount() {
+    // thanks to https://github.com/ReactTraining/react-router/issues/394#issuecomment-220221604
+    const { hash } = window.location;
+    const id = hash.replace('#', '');
+    if (id === this.props.name) {
+      setTimeout(() => {
+        this.element.scrollIntoView();
+      }, 0);
+    }
+  }
+
+  render() {
+    return <a ref={x => (this.element = x)} name={this.props.name} />;
+  }
+}

--- a/src/components/Anchor/index.js
+++ b/src/components/Anchor/index.js
@@ -1,6 +1,12 @@
 import React from 'react';
 
 /**
+ * This constant is used to correct the scroll bar position when navigating to an anchor
+ * Since we want the target element to appear below the scrollbar
+ */
+const TOP_BAR_HEIGHT = 110;
+
+/**
  * Creates an anchor class that scrolls to its possition if the correct hash has been specified
  * Only when the component is loaded
  */
@@ -11,7 +17,9 @@ export default class Anchor extends React.Component {
     const id = hash.replace('#', '');
     if (id === this.props.name) {
       setTimeout(() => {
-        this.element.scrollIntoView();
+        const offset = this.element.offsetTop;
+        // Substract the top bar height from the element's position
+        window.scrollTo({ top: offset - TOP_BAR_HEIGHT });
       }, 0);
     }
   }

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -38,3 +38,11 @@
     color: $black;    
   }
 }
+
+
+// For some reason `a` elements styled as buttons don't have the same height.
+// This rule fixes that
+a.button {
+  padding-top: 7px;
+  padding-bottom: 7px;
+}

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -9,6 +9,7 @@
   font-size: 1rem;
   line-height: 1.5;
   padding: 4px 24px;
+  display: inline-block;
 
   &--secondary {
     background: none;
@@ -37,12 +38,4 @@
     padding: 0;
     color: $black;    
   }
-}
-
-
-// For some reason `a` elements styled as buttons don't have the same height.
-// This rule fixes that
-a.button {
-  padding-top: 7px;
-  padding-bottom: 7px;
 }

--- a/src/containers/Experiment/index.js
+++ b/src/containers/Experiment/index.js
@@ -101,51 +101,54 @@ let Experiment = ({
               </div>
             </div>
 
-            <section id="samples" className="experiment__section">
-              <Anchor name="samples" />
-              <h2 className="experiment__title">Samples</h2>
-
-              <ReactTable
-                data={experiment.samples}
-                columns={[
-                  {
-                    Header: 'Sample ID',
-                    accessor: 'id'
-                  },
-                  {
-                    Header: 'Title',
-                    accessor: 'title'
-                  },
-                  {
-                    Header: 'Age'
-                  },
-                  {
-                    Header: 'Gender'
-                  },
-                  {
-                    Header: 'Processing Information'
-                  }
-                ]}
-              >
-                {(state, makeTable, instance) => {
-                  return (
-                    <React.Fragment>
-                      <div className="experiment__sample-commands">
-                        <Button
-                          text="Add Page to Dataset"
-                          buttonStyle="secondary"
-                          onClick={() =>
-                            addSamplesToDataset(state.pageRows.map(x => x.id))
-                          }
-                        />
-                      </div>
-
-                      {makeTable()}
-                    </React.Fragment>
-                  );
-                }}
-              </ReactTable>
-            </section>
+            <Anchor name="samples">
+              {() => (
+                <section className="experiment__section">
+                  <h2 className="experiment__title">Samples</h2>
+                  <ReactTable
+                    data={experiment.samples}
+                    columns={[
+                      {
+                        Header: 'Sample ID',
+                        accessor: 'id'
+                      },
+                      {
+                        Header: 'Title',
+                        accessor: 'title'
+                      },
+                      {
+                        Header: 'Age'
+                      },
+                      {
+                        Header: 'Gender'
+                      },
+                      {
+                        Header: 'Processing Information'
+                      }
+                    ]}
+                  >
+                    {(state, makeTable, instance) => {
+                      return (
+                        <React.Fragment>
+                          <div className="experiment__sample-commands">
+                            <Button
+                              text="Add Page to Dataset"
+                              buttonStyle="secondary"
+                              onClick={() =>
+                                addSamplesToDataset(
+                                  state.pageRows.map(x => x.id)
+                                )
+                              }
+                            />
+                          </div>
+                          {makeTable()}
+                        </React.Fragment>
+                      );
+                    }}
+                  </ReactTable>
+                </section>
+              )}
+            </Anchor>
           </div>
         </div>
       )

--- a/src/containers/Experiment/index.js
+++ b/src/containers/Experiment/index.js
@@ -14,6 +14,7 @@ import MicroarrayIcon from '../../common/icons/microarray-badge.svg';
 
 import ReactTable from 'react-table';
 import 'react-table/react-table.css';
+import Anchor from '../../components/Anchor';
 
 let Experiment = ({
   fetch,
@@ -100,7 +101,8 @@ let Experiment = ({
               </div>
             </div>
 
-            <section className="experiment__section">
+            <section id="samples" className="experiment__section">
+              <Anchor name="samples" />
               <h2 className="experiment__title">Samples</h2>
 
               <ReactTable

--- a/src/containers/Header/index.js
+++ b/src/containers/Header/index.js
@@ -13,7 +13,7 @@ class Header extends React.Component {
 
   render() {
     return (
-      <header className="header">
+      <header className="header js-header">
         <div className="header__container">
           <div className="header__logo">
             <img src={logo} alt="refine.bio" />

--- a/src/containers/Results/Result/index.js
+++ b/src/containers/Results/Result/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import Button from '../../../components/Button';
 import AccessionIcon from '../../../common/icons/accession.svg';
 import organismIcon from '../../../common/icons/organism.svg';
@@ -72,7 +73,12 @@ const Result = ({ result, addedExperiment, isAdded, removedExperiment }) => {
       <p className="result__paragraph">{result.publication_title}</p>
       <h3>Sample Metadata Fields</h3>
       <p className="result__paragraph">todo...</p>
-      <Button buttonStyle="secondary" text="View Samples" />
+      <Link
+        className="button button--secondary"
+        to={`/experiments/${result.id}#samples`}
+      >
+        View Samples
+      </Link>
     </div>
   );
 };


### PR DESCRIPTION
## Issue Number

closes #17 

## Purpose/Implementation Notes

When user clicks on "View Samples" button for an individual experiment in their search results, it should take them to the experiment page for that experiment and anchor them at the samples table section.

## Types of changes

* [x] New feature (non-breaking change which adds functionality)

## Functional tests

- In Results page, clicked View Samples, and it displayed the samples table directly

## Screenshots

![anchor2](https://user-images.githubusercontent.com/1882507/40493450-c79daac0-5f40-11e8-925f-37b4c99c6f29.gif)



