### PR TITLE
Ramenhog/feature/pagination shifting

### DIFF
--- a/src/components/Pagination/index.js
+++ b/src/components/Pagination/index.js
@@ -23,13 +23,41 @@ class Pagination extends Component {
     this.setState({ pageNumber: value });
   }
 
+  getPaginationRange(currentPage, totalPages) {
+    if (currentPage <= 2) {
+      return [2, 3];
+    } else if (currentPage >= totalPages - 1) {
+      return [totalPages - 2, totalPages - 1];
+    } else {
+      return [currentPage - 1, currentPage, currentPage + 1];
+    }
+  }
+
   renderPages() {
     const { totalPages, onPaginate, currentPage } = this.props;
 
-    const pageArray = totalPages < 5 ? getRange(totalPages) : [1, 2, 3];
+    const pageArray =
+      totalPages < 5
+        ? getRange(totalPages)
+        : this.getPaginationRange(currentPage, totalPages);
 
     return (
       <span>
+        {totalPages < 5 ? null : (
+          <span>
+            <button
+              onClick={() => onPaginate(1)}
+              className={`pagination__page ${
+                currentPage === totalPages ? 'pagination__page--active' : ''
+              }`}
+            >
+              1
+            </button>
+            {currentPage > 3 && (
+              <span className="pagination__ellipsis">...</span>
+            )}
+          </span>
+        )}
         {pageArray.map((page, i) => {
           return (
             <button
@@ -45,7 +73,9 @@ class Pagination extends Component {
         })}
         {totalPages < 5 ? null : (
           <span>
-            <span className="pagination__ellipsis">...</span>
+            {currentPage < totalPages - 2 && (
+              <span className="pagination__ellipsis">...</span>
+            )}
             <button
               onClick={() => onPaginate(totalPages)}
               className={`pagination__page ${

--- a/src/components/Pagination/index.js
+++ b/src/components/Pagination/index.js
@@ -48,7 +48,7 @@ class Pagination extends Component {
             <button
               onClick={() => onPaginate(1)}
               className={`pagination__page ${
-                currentPage === totalPages ? 'pagination__page--active' : ''
+                currentPage === 1 ? 'pagination__page--active' : ''
               }`}
             >
               1


### PR DESCRIPTION
## Issue Number
Closes #40 

## Purpose/Implementation Notes
Pagination range should shift as user paginates.

## Types of changes
* [ ] Bugfix (non-breaking change which fixes an issue)

## Functional tests
* as user paginates, the range of page numbers shifts so the current page is always the middle number unless it is the first or last page

## Screenshots
![issue-40](https://user-images.githubusercontent.com/4724065/40744649-3f551a58-6423-11e8-9465-c4b72bb3d955.gif)

