### PR TITLE
Arielsvn/support/23 sample table fields

### DIFF
--- a/src/api/samples.js
+++ b/src/api/samples.js
@@ -8,6 +8,10 @@ export async function getDetailedSample(sampleId) {
   return asyncFetch(`/samples/${sampleId}/`);
 }
 
+/**
+ * Returns all the details of the samples ids given
+ * @param {Array} sampleIds Ids of the samples
+ */
 export async function getAllDetailedSamples(sampleIds) {
   return Promise.all(sampleIds.map(id => getDetailedSample(id)));
 }

--- a/src/api/samples.js
+++ b/src/api/samples.js
@@ -1,0 +1,13 @@
+import { asyncFetch } from '../common/helpers';
+
+/**
+ * Returns detailed information for the given sample id
+ * @param {number} sampleId Id of the Sample
+ */
+export async function getDetailedSample(sampleId) {
+  return asyncFetch(`/samples/${sampleId}/`);
+}
+
+export async function getAllDetailedSamples(sampleIds) {
+  return Promise.all(sampleIds.map(id => getDetailedSample(id)));
+}

--- a/src/containers/Experiment/SamplesTable.js
+++ b/src/containers/Experiment/SamplesTable.js
@@ -209,17 +209,17 @@ export default class SamplesTable extends React.Component {
 
     // 2. count the number of samples that have a value for each column
     for (let column of columns) {
-      column.__total_values = data.reduce(
+      column.__totalValues = data.reduce(
         (total, sample) => total + (!!column.accessor(sample) ? 1 : 0),
         0
       );
     }
     columns = columns.sort(
-      (column1, column2) => column2.__total_values - column1.__total_values
+      (column1, column2) => column2.__totalValues - column1.__totalValues
     );
 
     // 3. Filter out the columns that don't have a value
-    columns = columns.filter(column => column.__total_values > 0);
+    columns = columns.filter(column => column.__totalValues > 0);
 
     // Return the final list of columns, the last two are always the same
     return [
@@ -237,7 +237,8 @@ export default class SamplesTable extends React.Component {
       ...columns,
       {
         Header: 'Processing Information',
-        id: 'processing_information'
+        id: 'processing_information',
+        sortable: false
       }
       // {
       //   Header: 'Add/Remove',


### PR DESCRIPTION
## Issue Number

#23 

## Purpose/Implementation Notes

Adds the following columns to the Samples Table: `title`, `accession_code`, `sex`, `age`, `specimen_part`, `genotype`, `disease`, `disease_stage`, `cell_line`, `treatment`, `race`, `subject`, `compound`, `time`. 

The columns are hidden when they are empty, and the ones that have more values are displayed first.

In this PR, we're doing an individual request for each sample in the samples table with the pagination done in the front end. So there's no sorting of the samples working here. We'll change this to use an additional endpoint that is able to retrieve all the samples information in a single request, and also provides the ability to sort them

## Types of changes

* [x] New feature (non-breaking change which adds functionality)

## Functional tests

- Checked that the table worked for several experiments
- Add Samples in the current page to the Data Set works
- Changing the current page and the page size triggers new requests

## Checklist

* [x] Lint and unit tests pass locally with my changes

## Screenshots

![async samples table](https://user-images.githubusercontent.com/1882507/40793893-ab020cd6-64cb-11e8-967c-3309dfeed8c4.gif)

For another experiment:

![image](https://user-images.githubusercontent.com/1882507/40793912-b7e0aeee-64cb-11e8-9fc4-3d3d2db78c65.png)

