### PR TITLE
Arielsvn/support/23 samples table sorting

### DIFF
--- a/src/api/samples.js
+++ b/src/api/samples.js
@@ -1,4 +1,4 @@
-import { asyncFetch } from '../common/helpers';
+import { asyncFetch, Ajax } from '../common/helpers';
 
 /**
  * Returns detailed information for the given sample id
@@ -10,8 +10,17 @@ export async function getDetailedSample(sampleId) {
 
 /**
  * Returns all the details of the samples ids given
- * @param {Array} sampleIds Ids of the samples
+ * @param {Array} ids Ids of the samples
+ * @param {orderBy} ids Field to sort the samples eg(title or -title). ref https://github.com/AlexsLemonade/refinebio/pull/298#issue-191878045
+ * @param {number} offset
+ * @param {number} limit
  */
-export async function getAllDetailedSamples(sampleIds) {
-  return Promise.all(sampleIds.map(id => getDetailedSample(id)));
+export async function getAllDetailedSamples({ ids, orderBy, offset, limit }) {
+  let { results } = await Ajax.get('/samples/', {
+    ids,
+    offset,
+    limit,
+    order_by: orderBy
+  });
+  return results;
 }

--- a/src/common/helpers.js
+++ b/src/common/helpers.js
@@ -68,3 +68,24 @@ export function getAmazonDownloadLinkUrl(s3_bucket, s3_key) {
 export function getDomain() {
   return window.location.origin;
 }
+
+// Helper methods to ease working with ajax functions
+export const Ajax = {
+  get: (url, params) => asyncFetch(`${url}?${getQueryString(params)}`),
+  put: (url, params) =>
+    asyncFetch(url, {
+      method: 'PUT',
+      headers: {
+        'content-type': 'application/json'
+      },
+      body: JSON.stringify(params)
+    }),
+  post: (url, params) =>
+    asyncFetch(url, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json'
+      },
+      body: JSON.stringify(params)
+    })
+};

--- a/src/containers/Experiment/SamplesTable.js
+++ b/src/containers/Experiment/SamplesTable.js
@@ -98,18 +98,35 @@ export default class SamplesTable extends React.Component {
     );
   }
 
-  fetchData = async () => {
+  fetchData = async (tableState = false) => {
     const { page, pageSize } = this.state;
-    this.setState({ loading: true });
-    const samples = this.props.samples
-      .slice(page * pageSize, (page + 1) * pageSize)
-      .map(sample => sample.id);
 
-    // TODO Right now we're paginating using the ids of the samples associated with the details of
-    // the current experiment, and with those ids, this is fetching detailed information for each one
-    // of them in a sepparate request.
-    // We'll change this to use a single endpoint from the server and sort the samples information.
-    const data = await getAllDetailedSamples(samples);
+    let orderBy = undefined;
+    if (tableState) {
+      const { sorted } = tableState;
+      // check table sort
+      if (sorted && sorted.length > 0) {
+        // we don't support sorting by multiple columns, so only consider the first one
+        const { id, desc } = sorted[0];
+        orderBy = `${desc ? '-' : ''}${id}`;
+      } else {
+        orderBy = undefined;
+      }
+    } else {
+      orderBy = this.state.orderBy;
+    }
+
+    this.setState({ loading: true, orderBy });
+    const sampleIds = this.props.samples.map(sample => sample.id);
+
+    let offset = page * pageSize;
+
+    const data = await getAllDetailedSamples({
+      ids: sampleIds,
+      orderBy,
+      offset,
+      limit: pageSize
+    });
 
     // Customize the columns and their order depending on de data
     let columns = this._getColumns(data);
@@ -143,67 +160,80 @@ export default class SamplesTable extends React.Component {
       {
         Header: 'Accession Code',
         id: 'accession_code',
-        accessor: d => d.accession_code
+        accessor: d => d.accession_code,
+        minWidth: 160
       },
       {
         Header: 'Sex',
         id: 'sex',
-        accessor: d => d.sex
+        accessor: d => d.sex,
+        minWidth: 160
       },
       {
         Header: 'Age',
         id: 'age',
-        accessor: d => d.age
+        accessor: d => d.age,
+        minWidth: 160
       },
       {
         Header: 'Specimen Part',
         id: 'specimen_part',
-        accessor: d => d.specimen_part
+        accessor: d => d.specimen_part,
+        minWidth: 160
       },
       {
         Header: 'Genotype',
         id: 'genotype',
-        accessor: d => d.genotype
+        accessor: d => d.genotype,
+        minWidth: 160
       },
       {
         Header: 'Disease',
         id: 'disease',
-        accessor: d => d.disease
+        accessor: d => d.disease,
+        minWidth: 160
       },
       {
         Header: 'Disease Stage',
         id: 'disease_stage',
-        accessor: d => d.disease_stage
+        accessor: d => d.disease_stage,
+        minWidth: 160
       },
       {
         Header: 'Cell line',
         id: 'cell_line',
-        accessor: d => d.cell_line
+        accessor: d => d.cell_line,
+        minWidth: 160
       },
       {
         Header: 'Treatment',
         id: 'treatment',
-        accessor: d => d.treatment
+        accessor: d => d.treatment,
+        minWidth: 160
       },
       {
         Header: 'Race',
         id: 'race',
-        accessor: d => d.race
+        accessor: d => d.race,
+        minWidth: 160
       },
       {
         Header: 'Subject',
         id: 'subject',
-        accessor: d => d.subject
+        accessor: d => d.subject,
+        minWidth: 160
       },
       {
         Header: 'Compound',
         id: 'compound',
-        accessor: d => d.compound
+        accessor: d => d.compound,
+        minWidth: 160
       },
       {
         Header: 'Time',
         id: 'time',
-        accessor: d => d.time
+        accessor: d => d.time,
+        minWidth: 160
       }
     ];
 
@@ -232,7 +262,7 @@ export default class SamplesTable extends React.Component {
         Header: 'Title',
         id: 'title',
         accessor: d => d.title,
-        minWidth: 140
+        minWidth: 180
       },
       ...columns,
       {

--- a/src/containers/Experiment/SamplesTable.js
+++ b/src/containers/Experiment/SamplesTable.js
@@ -99,25 +99,12 @@ export default class SamplesTable extends React.Component {
   }
 
   fetchData = async (tableState = false) => {
+    const sampleIds = this.props.samples.map(sample => sample.id);
     const { page, pageSize } = this.state;
-
-    let orderBy = undefined;
-    if (tableState) {
-      const { sorted } = tableState;
-      // check table sort
-      if (sorted && sorted.length > 0) {
-        // we don't support sorting by multiple columns, so only consider the first one
-        const { id, desc } = sorted[0];
-        orderBy = `${desc ? '-' : ''}${id}`;
-      } else {
-        orderBy = undefined;
-      }
-    } else {
-      orderBy = this.state.orderBy;
-    }
+    // get the backend ready `order_by` param, based on the sort options from the table
+    let orderBy = this._getSortParam(tableState);
 
     this.setState({ loading: true, orderBy });
-    const sampleIds = this.props.samples.map(sample => sample.id);
 
     let offset = page * pageSize;
 
@@ -282,6 +269,29 @@ export default class SamplesTable extends React.Component {
       //   id: 'add_remove'
       // }
     ];
+  }
+
+  /**
+   * Returns the sort parameter as required from the backend
+   * @param {*} tableState State from the table, as given to `fetchData`
+   */
+  _getSortParam(tableState) {
+    let orderBy = undefined;
+    if (tableState) {
+      const { sorted } = tableState;
+      // check table sort
+      if (sorted && sorted.length > 0) {
+        // we don't support sorting by multiple columns, so only consider the first one
+        const { id, desc } = sorted[0];
+        // ref: https://github.com/AlexsLemonade/refinebio/pull/298
+        orderBy = `${desc ? '-' : ''}${id}`;
+      } else {
+        orderBy = undefined;
+      }
+    } else {
+      orderBy = this.state.orderBy;
+    }
+    return orderBy;
   }
 }
 

--- a/src/containers/Experiment/SamplesTable.js
+++ b/src/containers/Experiment/SamplesTable.js
@@ -145,7 +145,14 @@ export default class SamplesTable extends React.Component {
   };
 
   handlePageSizeChange = pageSize => {
-    this.setState({ pageSize }, () => this.fetchData());
+    let page = this.state.page;
+    // check if the page is outside of the new page range
+    if ((page + 1) * pageSize > this.props.samples.length) {
+      // set the page to the last one
+      page = Math.floor(this.props.samples.length / pageSize);
+    }
+
+    this.setState({ page, pageSize }, () => this.fetchData());
   };
 
   /**


### PR DESCRIPTION
## Issue Number

Close #23 

## Purpose/Implementation Notes

Used sample details endpoint to fetch the samples associated with an experiment. Also added the ability to sort the table passing the corresponding parameters to the endpoint.

The request urls will looks like: http://localhost:3000/samples/?ids=241,242,243,244,245,246,247,248,249,250,251,252,253,254,255,256,257,258,259,260,261,262,263,264,265,266,267,268,269,270,271,272,273,274,275,276,277,278,279,280,281,282,283,284,285,286,287,288,289,290,291,292,293,294,295,296,297,298,299,300,301,302,303,304&offset=0&limit=10&order_by=-title

## Types of changes

* [x] New feature (non-breaking change which adds functionality)

## Functional tests

- Check that the table renders the samples associated with an experiment
- Sort table and check pagination

## Screenshots

![samples sorting](https://user-images.githubusercontent.com/1882507/40851650-16e08264-6596-11e8-96ae-ba2e2ab4911e.gif)

