### PR TITLE
Connect view samples table on downloads page

### DIFF
--- a/src/containers/Downloads/DownloadDetails.js
+++ b/src/containers/Downloads/DownloadDetails.js
@@ -8,6 +8,9 @@ import TabControl from '../../components/TabControl';
 import DownloadFileSummary from './DownloadFileSummary';
 import DownloadDatasetSummary from './DownloadDatasetSummary';
 
+import ModalManager from '../../components/Modal/ModalManager';
+import SamplesTable from '../Experiment/SamplesTable';
+
 export default function DownloadDetails({
   dataSet,
   filesData,
@@ -68,7 +71,21 @@ const SpeciesSamples = ({ samplesBySpecies, removeSpecies }) => {
             {species[speciesName].length > 1 ? 'Samples' : 'Sample'}
           </p>
         </div>
-        <Button text="View Samples" buttonStyle="secondary" />
+
+        <ModalManager
+          component={showModal => (
+            <Button
+              text="View Samples"
+              buttonStyle="secondary"
+              onClick={showModal}
+            />
+          )}
+          modalProps={{ className: 'samples-modal' }}
+        >
+          {() => (
+            <SamplesTable sampleIds={species[speciesName].map(x => x.id)} />
+          )}
+        </ModalManager>
       </div>
 
       {removeSpecies && (
@@ -121,7 +138,21 @@ const ExperimentsView = ({ dataSet, experiments, removeExperiment }) => {
           </div>
           <h4>Sample Metadata Fields</h4>
           <h5>{experiment.metadata ? experiment.metadata.join(', ') : null}</h5>
-          <Button text="View Samples" buttonStyle="secondary" />
+
+          {experiment.samples.length > 0 && (
+            <ModalManager
+              component={showModal => (
+                <Button
+                  text="View Samples"
+                  buttonStyle="secondary"
+                  onClick={showModal}
+                />
+              )}
+              modalProps={{ className: 'samples-modal' }}
+            >
+              {() => <SamplesTable sampleIds={experiment.samples} />}
+            </ModalManager>
+          )}
         </div>
         {removeExperiment && (
           <Button

--- a/src/containers/Downloads/Downloads.scss
+++ b/src/containers/Downloads/Downloads.scss
@@ -133,3 +133,10 @@
     margin-bottom: 0.5rem;
   }
 }
+
+
+
+
+.samples-modal {
+  max-width: 950px;
+}

--- a/src/containers/Experiment/SamplesTable.js
+++ b/src/containers/Experiment/SamplesTable.js
@@ -26,7 +26,7 @@ export default class SamplesTable extends React.Component {
   }
 
   render() {
-    const { sampleIds, pageActionComponent } = this.props;
+    const { pageActionComponent } = this.props;
     // `pageActionComponent` is a render prop to add a component at the top right of the table
     // Good for a add/remove samples button. It's a function that receives the currently displayed
     // samples as an argument

--- a/src/containers/Experiment/SamplesTable.js
+++ b/src/containers/Experiment/SamplesTable.js
@@ -5,9 +5,7 @@ import 'react-table/react-table.css';
 
 import Pagination from '../../components/Pagination';
 import Dropdown from '../../components/Dropdown';
-import { RemoveFromDatasetButton } from '../Results/Result';
 import { getAllDetailedSamples } from '../../api/samples';
-import { AnonymousSubject } from 'rxjs';
 import ModalManager from '../../components/Modal/ModalManager';
 
 import './SamplesTable.scss';
@@ -24,7 +22,7 @@ export default class SamplesTable extends React.Component {
   };
 
   render() {
-    const { samples, dataSet, pageActionComponent } = this.props;
+    const { samples, pageActionComponent } = this.props;
     // `pageActionComponent` is a render prop to add a component at the top right of the table
     // Good for a add/remove samples button. It's a function that receives the currently displayed
     // samples as an argument

--- a/src/containers/Experiment/SamplesTable.js
+++ b/src/containers/Experiment/SamplesTable.js
@@ -21,13 +21,16 @@ export default class SamplesTable extends React.Component {
     data: []
   };
 
+  get totalSamples() {
+    return this.props.sampleIds.length;
+  }
+
   render() {
-    const { samples, pageActionComponent } = this.props;
+    const { sampleIds, pageActionComponent } = this.props;
     // `pageActionComponent` is a render prop to add a component at the top right of the table
     // Good for a add/remove samples button. It's a function that receives the currently displayed
     // samples as an argument
-    const totalPages = Math.ceil(samples.length / this.state.pageSize);
-
+    const totalPages = Math.ceil(this.totalSamples / this.state.pageSize);
     return (
       <ReactTable
         manual={true}
@@ -54,7 +57,7 @@ export default class SamplesTable extends React.Component {
                     selectedOption={this.state.pageSize}
                     onChange={this.handlePageSizeChange}
                   />
-                  of {samples.length} Samples
+                  of {this.totalSamples} Samples
                 </div>
                 {pageActionComponent &&
                   pageActionComponent(state.pageRows.map(x => x._original))}
@@ -74,7 +77,7 @@ export default class SamplesTable extends React.Component {
   }
 
   fetchData = async (tableState = false) => {
-    const sampleIds = this.props.samples.map(sample => sample.id);
+    const sampleIds = this.props.sampleIds;
     const { page, pageSize } = this.state;
     // get the backend ready `order_by` param, based on the sort options from the table
     let orderBy = this._getSortParam(tableState);
@@ -96,7 +99,7 @@ export default class SamplesTable extends React.Component {
     this.setState({
       data,
       columns,
-      pages: Math.ceil(this.props.samples.length / pageSize),
+      pages: Math.ceil(this.totalSamples / pageSize),
       loading: false
     });
   };
@@ -109,9 +112,9 @@ export default class SamplesTable extends React.Component {
   handlePageSizeChange = pageSize => {
     let page = this.state.page;
     // check if the page is outside of the new page range
-    if ((page + 1) * pageSize > this.props.samples.length) {
+    if ((page + 1) * pageSize > this.totalSamples) {
       // set the page to the last one
-      page = Math.floor(this.props.samples.length / pageSize);
+      page = Math.floor(this.totalSamples / pageSize);
     }
 
     this.setState({ page, pageSize }, () => this.fetchData());

--- a/src/containers/Experiment/SamplesTable.js
+++ b/src/containers/Experiment/SamplesTable.js
@@ -23,18 +23,11 @@ export default class SamplesTable extends React.Component {
     data: []
   };
 
-  handleAddSamplesToDataset = samples => {
-    const { accessionCode: accession_code, addSamplesToDataset } = this.props;
-    addSamplesToDataset([{ accession_code, samples }]);
-  };
-
-  handleRemoveSamplesFromDataset = sampleIds => {
-    const { accessionCode, removeSamplesFromDataset } = this.props;
-    removeSamplesFromDataset(accessionCode, sampleIds);
-  };
-
   render() {
-    const { samples, dataSet, accessionCode } = this.props;
+    const { samples, dataSet, pageActionComponent } = this.props;
+    // `pageActionComponent` is a render prop to add a component at the top right of the table
+    // Good for a add/remove samples button. It's a function that receives the currently displayed
+    // samples as an argument
     const totalPages = Math.ceil(samples.length / this.state.pageSize);
 
     return (
@@ -53,11 +46,6 @@ export default class SamplesTable extends React.Component {
         ThComponent={ThComponent}
       >
         {(state, makeTable, instance) => {
-          const samplesNotInDataset = state.pageRows.filter(x => {
-            if (!dataSet[accessionCode]) return true;
-            return dataSet[accessionCode].indexOf(x.id) === -1;
-          });
-
           return (
             <div>
               <div className="experiment__sample-commands">
@@ -70,23 +58,8 @@ export default class SamplesTable extends React.Component {
                   />
                   of {samples.length} Samples
                 </div>
-                {samplesNotInDataset.length === 0 ? (
-                  <RemoveFromDatasetButton
-                    handleRemove={() =>
-                      this.handleRemoveSamplesFromDataset(
-                        state.pageRows.map(sample => sample.id)
-                      )
-                    }
-                  />
-                ) : (
-                  <Button
-                    text="Add Page to Dataset"
-                    buttonStyle="secondary"
-                    onClick={() =>
-                      this.handleAddSamplesToDataset(state.pageRows)
-                    }
-                  />
-                )}
+                {pageActionComponent &&
+                  pageActionComponent(state.pageRows.map(x => x._original))}
               </div>
               <div className="experiment__table-container">{makeTable()}</div>
 

--- a/src/containers/Experiment/index.js
+++ b/src/containers/Experiment/index.js
@@ -135,7 +135,7 @@ let Experiment = ({
                 <section className="experiment__section">
                   <h2 className="experiment__title">Samples</h2>
                   <SamplesTable
-                    samples={experiment.samples}
+                    sampleIds={experiment.samples.map(x => x.id)}
                     // Render prop for the button that adds the samples to the dataset
                     pageActionComponent={samplesDisplayed =>
                       samplesNotInDataSet(

--- a/src/containers/Experiment/index.js
+++ b/src/containers/Experiment/index.js
@@ -137,35 +137,9 @@ let Experiment = ({
                   <SamplesTable
                     sampleIds={experiment.samples.map(x => x.id)}
                     // Render prop for the button that adds the samples to the dataset
-                    pageActionComponent={samplesDisplayed =>
-                      samplesNotInDataSet(
-                        samplesDisplayed,
-                        experiment.accession_code,
-                        dataSet
-                      ).length === 0 ? (
-                        <RemoveFromDatasetButton
-                          handleRemove={() =>
-                            removeSamplesFromExperiment(
-                              experiment.accession_code,
-                              samplesDisplayed.map(x => x.id)
-                            )
-                          }
-                        />
-                      ) : (
-                        <Button
-                          text="Add Page to Dataset"
-                          buttonStyle="secondary"
-                          onClick={() =>
-                            addExperiment([
-                              {
-                                accession_code: experiment.accession_code,
-                                samples: samplesDisplayed
-                              }
-                            ])
-                          }
-                        />
-                      )
-                    }
+                    pageActionComponent={samplesDisplayed => (
+                      <SampleTableActions samples={samplesDisplayed} />
+                    )}
                   />
                 </section>
               )}
@@ -194,6 +168,55 @@ Experiment = connect(
 )(Experiment);
 
 export default Experiment;
+
+/**
+ * This component is used for the top-right part of the Samples table, manages adding a set of samples
+ * to the current dataset. Sample usage:
+ * <SampleTableActions samples={samplesDisplayed} />
+ */
+let SampleTableActions = ({
+  samples,
+  allSamplesInDataset,
+  experiment,
+  removeSamplesFromExperiment,
+  addExperiment
+}) =>
+  allSamplesInDataset ? (
+    <RemoveFromDatasetButton
+      handleRemove={() =>
+        removeSamplesFromExperiment(
+          experiment.accession_code,
+          samples.map(x => x.id)
+        )
+      }
+    />
+  ) : (
+    <Button
+      text="Add Page to Dataset"
+      buttonStyle="secondary"
+      onClick={() =>
+        addExperiment([
+          {
+            accession_code: experiment.accession_code,
+            samples: samples
+          }
+        ])
+      }
+    />
+  );
+SampleTableActions = connect(
+  ({ experiment, download: { dataSet } }, { samples }) => ({
+    experiment,
+    // should be true if all samples passed are already in the dataset
+    allSamplesInDataset:
+      samplesNotInDataSet(samples, experiment.accession_code, dataSet)
+        .length === 0
+  }),
+  {
+    addExperiment,
+    removeSamplesFromExperiment
+  }
+)(SampleTableActions);
 
 function samplesNotInDataSet(samples, accessionCode, dataSet) {
   return samples.filter(x => {

--- a/src/containers/Experiment/index.js
+++ b/src/containers/Experiment/index.js
@@ -135,11 +135,38 @@ let Experiment = ({
                 <section className="experiment__section">
                   <h2 className="experiment__title">Samples</h2>
                   <SamplesTable
-                    accessionCode={experiment.accession_code}
                     samples={experiment.samples}
-                    addSamplesToDataset={addExperiment}
-                    removeSamplesFromDataset={removeSamplesFromExperiment}
                     dataSet={dataSet}
+                    // Render prop for the button that adds the samples to the dataset
+                    pageActionComponent={samplesDisplayed =>
+                      samplesNotInDataSet(
+                        samplesDisplayed,
+                        experiment.accession_code,
+                        dataSet
+                      ).length === 0 ? (
+                        <RemoveFromDatasetButton
+                          handleRemove={() =>
+                            removeSamplesFromExperiment(
+                              experiment.accession_code,
+                              samplesDisplayed.map(x => x.id)
+                            )
+                          }
+                        />
+                      ) : (
+                        <Button
+                          text="Add Page to Dataset"
+                          buttonStyle="secondary"
+                          onClick={() =>
+                            addExperiment([
+                              {
+                                accession_code: experiment.accession_code,
+                                samples: samplesDisplayed
+                              }
+                            ])
+                          }
+                        />
+                      )
+                    }
                   />
                 </section>
               )}
@@ -168,3 +195,10 @@ Experiment = connect(
 )(Experiment);
 
 export default Experiment;
+
+function samplesNotInDataSet(samples, accessionCode, dataSet) {
+  return samples.filter(x => {
+    if (!dataSet[accessionCode]) return true;
+    return dataSet[accessionCode].indexOf(x.id) === -1;
+  });
+}

--- a/src/containers/Experiment/index.js
+++ b/src/containers/Experiment/index.js
@@ -136,7 +136,6 @@ let Experiment = ({
                   <h2 className="experiment__title">Samples</h2>
                   <SamplesTable
                     samples={experiment.samples}
-                    dataSet={dataSet}
                     // Render prop for the button that adds the samples to the dataset
                     pageActionComponent={samplesDisplayed =>
                       samplesNotInDataSet(


### PR DESCRIPTION
## Issue Number

Close #26 

## Purpose/Implementation Notes

Adds modals dialogs on the Download page with the samples associated to each experiment and specie.

I noticed a bug on the ModalManager, and reported it on #53

## Types of changes

* [x] New feature (non-breaking change which adds functionality)

## Functional tests

- Open downloads page, and click view samples on the species
- Same for experiments on the other tab

## Screenshots

Samples for Homo Sapiens specie:

![image](https://user-images.githubusercontent.com/1882507/40940851-146345b6-6817-11e8-8275-65800032febe.png)

Samples for experiment:

![image](https://user-images.githubusercontent.com/1882507/40940884-2653a32e-6817-11e8-9c38-a7699e405e51.png)




