### PR TITLE
Refactor usages of `asyncFetch` and use `Ajax` instead

### DIFF
--- a/src/api/dataSet.js
+++ b/src/api/dataSet.js
@@ -1,7 +1,7 @@
-import { asyncFetch } from '../common/helpers';
+import { Ajax } from '../common/helpers';
 
 export async function getDataSet(dataSetId) {
-  return await asyncFetch(`/dataset/${dataSetId}/`);
+  return await Ajax.get(`/dataset/${dataSetId}/`);
 }
 
 export async function getSamplesAndExperiments(dataSet) {
@@ -10,18 +10,19 @@ export async function getSamplesAndExperiments(dataSet) {
 
   await Promise.all(
     Object.keys(dataSet).map(async accessionCode => {
-      const experiment = await asyncFetch(
-        `/experiments/?accession_code=${accessionCode}`
-      );
+      const experiment = await Ajax.get('/experiments/', {
+        accession_code: accessionCode
+      });
 
       experiments[accessionCode] = experiment.results[0];
 
       // there should only be one result for each experiment response
       const experimentInfo = experiment.results[0];
       const { samples: sampleList } = experimentInfo;
-      const response = await asyncFetch(
-        `/samples/?limit=1000000000000000&ids=${sampleList.join(',')}`
-      );
+      const response = await Ajax.get('/samples/', {
+        limit: 1000000000000000,
+        ids: sampleList.join(',')
+      });
       const sampleInfo = response.results;
 
       samples[accessionCode] = sampleInfo;
@@ -32,13 +33,5 @@ export async function getSamplesAndExperiments(dataSet) {
 }
 
 export async function updateDataSet(dataSetId, dataSet) {
-  return await asyncFetch(`/dataset/${dataSetId}/`, {
-    method: 'PUT',
-    headers: {
-      'content-type': 'application/json'
-    },
-    body: JSON.stringify({
-      data: dataSet
-    })
-  });
+  return await Ajax.put(`/dataset/${dataSetId}/`, { data: dataSet });
 }

--- a/src/api/samples.js
+++ b/src/api/samples.js
@@ -1,11 +1,11 @@
-import { asyncFetch, Ajax } from '../common/helpers';
+import { Ajax } from '../common/helpers';
 
 /**
  * Returns detailed information for the given sample id
  * @param {number} sampleId Id of the Sample
  */
 export async function getDetailedSample(sampleId) {
-  return asyncFetch(`/samples/${sampleId}/`);
+  return Ajax.get(`/samples/${sampleId}/`);
 }
 
 /**

--- a/src/common/helpers.js
+++ b/src/common/helpers.js
@@ -76,8 +76,13 @@ export function formatSentenceCase(str) {
 
 // Helper methods to ease working with ajax functions
 export const Ajax = {
-  get: (url, params) => asyncFetch(`${url}?${getQueryString(params)}`),
-  put: (url, params) =>
+  get: (url, params = false) => {
+    if (params) {
+      return asyncFetch(`${url}?${getQueryString(params)}`);
+    }
+    return asyncFetch(url);
+  },
+  put: (url, params = {}) =>
     asyncFetch(url, {
       method: 'PUT',
       headers: {
@@ -85,7 +90,7 @@ export const Ajax = {
       },
       body: JSON.stringify(params)
     }),
-  post: (url, params) =>
+  post: (url, params = {}) =>
     asyncFetch(url, {
       method: 'POST',
       headers: {

--- a/src/containers/Experiment/SamplesTable.js
+++ b/src/containers/Experiment/SamplesTable.js
@@ -7,7 +7,6 @@ import Pagination from '../../components/Pagination';
 import Dropdown from '../../components/Dropdown';
 import { RemoveFromDatasetButton } from '../Results/Result';
 import { getAllDetailedSamples } from '../../api/samples';
-import { AnonymousSubject } from 'rxjs';
 import ModalManager from '../../components/Modal/ModalManager';
 
 import './SamplesTable.scss';

--- a/src/state/download/actions.js
+++ b/src/state/download/actions.js
@@ -1,4 +1,4 @@
-import { asyncFetch } from '../../common/helpers';
+import { Ajax } from '../../common/helpers';
 import {
   getDataSet,
   getSamplesAndExperiments,
@@ -151,12 +151,8 @@ export const addExperiment = experiments => {
     try {
       let response;
       if (!dataSetId) {
-        response = await asyncFetch('/dataset/create/', {
-          method: 'POST',
-          headers: {
-            'content-type': 'application/json'
-          },
-          body: JSON.stringify({ data: bodyData })
+        response = await Ajax.post('/dataset/create/', {
+          data: bodyData
         });
 
         const { id } = response;
@@ -233,17 +229,10 @@ export const fetchDataSetDetailsSucceeded = (experiments, samples) => {
 
 export const startDownload = () => async (dispatch, getState) => {
   const { dataSetId, dataSet } = getState().download;
-  await asyncFetch(`/dataset/${dataSetId}/`, {
-    method: 'PUT',
-    headers: {
-      'content-type': 'application/json'
-    },
-    body: JSON.stringify({
-      start: true,
-      data: dataSet
-    })
+  await Ajax.put(`/dataset/${dataSetId}/`, {
+    start: true,
+    data: dataSet
   });
-
   // Use `push` action to navigate to the dataset url
   dispatch(push(`/dataset/${dataSetId}`));
 };

--- a/src/state/experiment/actions.js
+++ b/src/state/experiment/actions.js
@@ -1,4 +1,4 @@
-import { asyncFetch } from '../../common/helpers';
+import { Ajax } from '../../common/helpers';
 
 const loadExperiment = data => ({
   type: 'LOAD_EXPERIMENT',
@@ -6,6 +6,6 @@ const loadExperiment = data => ({
 });
 
 export const fetchExperiment = id => async dispatch => {
-  const data = await asyncFetch(`/experiments/${id}/`);
+  const data = await Ajax.get(`/experiments/${id}/`);
   dispatch(loadExperiment(data));
 };


### PR DESCRIPTION
## Issue Number

#55 

## Purpose/Implementation Notes

Refactor usages of `asyncHelper` and use `Ajax` helper methods instead. This was suggested on https://github.com/AlexsLemonade/refinebio-frontend/pull/52#discussion_r192490968

## Types of changes

* [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

- Checked the requests on all pages to confirm they were being sent correctly (search page, experiments page, etc)
