### PR TITLE
Show sample metadata in search results

### DIFF
--- a/src/api/samples.js
+++ b/src/api/samples.js
@@ -16,11 +16,15 @@ export async function getDetailedSample(sampleId) {
  * @param {number} limit
  */
 export async function getAllDetailedSamples({ ids, orderBy, offset, limit }) {
-  let { results } = await Ajax.get('/samples/', {
-    ids,
-    offset,
-    limit,
-    order_by: orderBy
-  });
-  return results;
+  if (ids && ids.length) {
+    let { results } = await Ajax.get('/samples/', {
+      ids,
+      offset,
+      limit,
+      order_by: orderBy
+    });
+    return results;
+  } else {
+    return [];
+  }
 }

--- a/src/containers/Experiment/SampleFieldMetadata.js
+++ b/src/containers/Experiment/SampleFieldMetadata.js
@@ -1,0 +1,93 @@
+/**
+ * Description for each one of the fields for Samples
+ */
+const SampleFieldMetadata = [
+  {
+    Header: 'Title',
+    id: 'title',
+    accessor: d => d.title,
+    minWidth: 180
+  },
+  {
+    Header: 'Accession Code',
+    id: 'accession_code',
+    accessor: d => d.accession_code,
+    minWidth: 160
+  },
+  {
+    Header: 'Sex',
+    id: 'sex',
+    accessor: d => d.sex,
+    minWidth: 160
+  },
+  {
+    Header: 'Age',
+    id: 'age',
+    accessor: d => d.age,
+    minWidth: 160
+  },
+  {
+    Header: 'Specimen Part',
+    id: 'specimen_part',
+    accessor: d => d.specimen_part,
+    minWidth: 160
+  },
+  {
+    Header: 'Genotype',
+    id: 'genotype',
+    accessor: d => d.genotype,
+    minWidth: 160
+  },
+  {
+    Header: 'Disease',
+    id: 'disease',
+    accessor: d => d.disease,
+    minWidth: 160
+  },
+  {
+    Header: 'Disease Stage',
+    id: 'disease_stage',
+    accessor: d => d.disease_stage,
+    minWidth: 160
+  },
+  {
+    Header: 'Cell line',
+    id: 'cell_line',
+    accessor: d => d.cell_line,
+    minWidth: 160
+  },
+  {
+    Header: 'Treatment',
+    id: 'treatment',
+    accessor: d => d.treatment,
+    minWidth: 160
+  },
+  {
+    Header: 'Race',
+    id: 'race',
+    accessor: d => d.race,
+    minWidth: 160
+  },
+  {
+    Header: 'Subject',
+    id: 'subject',
+    accessor: d => d.subject,
+    minWidth: 160
+  },
+  {
+    Header: 'Compound',
+    id: 'compound',
+    accessor: d => d.compound,
+    minWidth: 160
+  },
+  {
+    Header: 'Time',
+    id: 'time',
+    accessor: d => d.time,
+    minWidth: 160
+  }
+];
+
+SampleFieldMetadata.forEach((x, index) => (x.index = index));
+
+export default SampleFieldMetadata;

--- a/src/containers/Experiment/SamplesTable.js
+++ b/src/containers/Experiment/SamplesTable.js
@@ -10,6 +10,7 @@ import { getAllDetailedSamples } from '../../api/samples';
 import ModalManager from '../../components/Modal/ModalManager';
 import FileIcon from './file.svg';
 import ProcessIcon from './process.svg';
+import SampleFieldMetadata from './SampleFieldMetadata';
 
 import './SamplesTable.scss';
 
@@ -155,96 +156,17 @@ export default class SamplesTable extends React.Component {
    */
   _getColumns(data = []) {
     // 1. define all columns
-    let columns = [
-      {
-        Header: 'Accession Code',
-        id: 'accession_code',
-        accessor: d => d.accession_code,
-        minWidth: 160
-      },
-      {
-        Header: 'Sex',
-        id: 'sex',
-        accessor: d => d.sex,
-        minWidth: 160
-      },
-      {
-        Header: 'Age',
-        id: 'age',
-        accessor: d => d.age,
-        minWidth: 160
-      },
-      {
-        Header: 'Specimen Part',
-        id: 'specimen_part',
-        accessor: d => d.specimen_part,
-        minWidth: 160
-      },
-      {
-        Header: 'Genotype',
-        id: 'genotype',
-        accessor: d => d.genotype,
-        minWidth: 160
-      },
-      {
-        Header: 'Disease',
-        id: 'disease',
-        accessor: d => d.disease,
-        minWidth: 160
-      },
-      {
-        Header: 'Disease Stage',
-        id: 'disease_stage',
-        accessor: d => d.disease_stage,
-        minWidth: 160
-      },
-      {
-        Header: 'Cell line',
-        id: 'cell_line',
-        accessor: d => d.cell_line,
-        minWidth: 160
-      },
-      {
-        Header: 'Treatment',
-        id: 'treatment',
-        accessor: d => d.treatment,
-        minWidth: 160
-      },
-      {
-        Header: 'Race',
-        id: 'race',
-        accessor: d => d.race,
-        minWidth: 160
-      },
-      {
-        Header: 'Subject',
-        id: 'subject',
-        accessor: d => d.subject,
-        minWidth: 160
-      },
-      {
-        Header: 'Compound',
-        id: 'compound',
-        accessor: d => d.compound,
-        minWidth: 160
-      },
-      {
-        Header: 'Time',
-        id: 'time',
-        accessor: d => d.time,
-        minWidth: 160
-      }
-    ];
-
     // 2. count the number of samples that have a value for each column
-    for (let column of columns) {
-      column.__totalValues = data.reduce(
+    let columns = SampleFieldMetadata.map(column => ({
+      ...column,
+      __totalValues: data.reduce(
         (total, sample) => total + (!!column.accessor(sample) ? 1 : 0),
         0
-      );
-    }
+      )
+    }));
+
     columns = columns.sort(
-      (column1, column2) => column2.__totalValues - column1.__totalValues
+      (column1, column2) => column2.__totalValues - column1.__totalValues - 1
     );
 
     // 3. Filter out the columns that don't have a value
@@ -256,12 +178,6 @@ export default class SamplesTable extends React.Component {
         id: 'id',
         accessor: d => d.id,
         show: false
-      },
-      {
-        Header: 'Title',
-        id: 'title',
-        accessor: d => d.title,
-        minWidth: 180
       },
       ...columns,
       {

--- a/src/containers/Results/Result/index.js
+++ b/src/containers/Results/Result/index.js
@@ -6,6 +6,9 @@ import OrganismIcon from '../../../common/icons/organism.svg';
 import SampleIcon from '../../../common/icons/sample.svg';
 import MicroarrayIcon from '../../../common/icons/microarray-badge.svg';
 import './Result.scss';
+import Loader from '../../../components/Loader';
+import { getAllDetailedSamples } from '../../../api/samples';
+import SampleFieldMetadata from '../../Experiment/SampleFieldMetadata';
 
 export function RemoveFromDatasetButton({
   handleRemove,
@@ -100,8 +103,9 @@ const Result = ({ result, addExperiment, removeExperiment, dataSet }) => {
       <p className="result__paragraph">{result.description}</p>
       <h3>Publication Title</h3>
       <p className="result__paragraph">{result.publication_title}</p>
-      <h3>Sample Metadata Fields</h3>
-      <p className="result__paragraph">todo...</p>
+
+      <SampleMetadataFields samples={result.samples} />
+
       <Link
         className="button button--secondary"
         to={`/experiments/${result.id}#samples`}
@@ -113,3 +117,32 @@ const Result = ({ result, addExperiment, removeExperiment, dataSet }) => {
 };
 
 export default Result;
+
+/**
+ * This component receives a list of samples, and renders the names of the fields that have values
+ * for those samples. It does so, by requesting the details of the first 10 samples and then showing
+ * the names of the fields that have any value associated.
+ */
+function SampleMetadataFields({ samples }) {
+  // request the details of the first 10 samples, and show the names of the fields that have any value
+  return (
+    <Loader fetch={() => getAllDetailedSamples({ ids: samples.slice(0, 10) })}>
+      {({ isLoading, data }) =>
+        !isLoading &&
+        data &&
+        data.length > 0 && (
+          <React.Fragment>
+            <h3>Sample Metadata Fields</h3>
+            <p className="result__paragraph">
+              {SampleFieldMetadata.filter(({ accessor }) =>
+                data.some(sample => !!accessor(sample))
+              )
+                .map(({ Header }) => Header)
+                .join(', ')}
+            </p>
+          </React.Fragment>
+        )
+      }
+    </Loader>
+  );
+}

--- a/src/containers/Results/index.js
+++ b/src/containers/Results/index.js
@@ -1,5 +1,4 @@
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 import * as resultsActions from '../../state/search/actions';
 import * as downloadActions from '../../state/download/actions';
 


### PR DESCRIPTION
## Issue Number

Close #16 

## Purpose/Implementation Notes

Shows sample metadata information for search results.

In this PR, we're doing a request to `/samples` for every result. In the future it might be better to include this information as metadata in the results endpoint.

## Types of changes

* [x] New feature (non-breaking change which adds functionality)

## Functional tests

- Checked the search results to see the names of the fields correctly displayed.

## Screenshots

![image](https://user-images.githubusercontent.com/1882507/41061026-5bbfdb34-699f-11e8-92ed-e88e4a529420.png)

![image](https://user-images.githubusercontent.com/1882507/41061028-61c20926-699f-11e8-921c-43a1a4df5ea3.png)


