### PR TITLE
Add dropdown to allow user changing number of results per page in search

### DIFF
--- a/src/constants/table.js
+++ b/src/constants/table.js
@@ -1,0 +1,1 @@
+export const PAGE_SIZES = [10, 20, 50];

--- a/src/containers/Experiment/SamplesTable.js
+++ b/src/containers/Experiment/SamplesTable.js
@@ -10,10 +10,9 @@ import { getAllDetailedSamples } from '../../api/samples';
 import ModalManager from '../../components/Modal/ModalManager';
 import FileIcon from './file.svg';
 import ProcessIcon from './process.svg';
+import { PAGE_SIZES } from '../../constants/table';
 
 import './SamplesTable.scss';
-
-const PAGE_SIZES = [10, 20, 50];
 
 export default class SamplesTable extends React.Component {
   state = {

--- a/src/containers/Results/Results.js
+++ b/src/containers/Results/Results.js
@@ -10,6 +10,7 @@ import './Results.scss';
 import { connect } from 'react-redux';
 import { updateResultsPerPage } from '../../state/search/actions';
 import Dropdown from '../../components/Dropdown';
+import { PAGE_SIZES } from '../../constants/table';
 
 class Results extends Component {
   componentDidMount() {
@@ -124,8 +125,6 @@ class Results extends Component {
 }
 
 export default Results;
-
-const PAGE_SIZES = [10, 20, 50];
 
 let NumberOfResults = ({
   resultsPerPage,

--- a/src/containers/Results/Results.js
+++ b/src/containers/Results/Results.js
@@ -7,6 +7,9 @@ import Button from '../../components/Button';
 import BackToTop from '../../components/BackToTop';
 import { getQueryParamObject } from '../../common/helpers';
 import './Results.scss';
+import { connect } from 'react-redux';
+import { updateResultsPerPage } from '../../state/search/actions';
+import Dropdown from '../../components/Dropdown';
 
 class Results extends Component {
   componentDidMount() {
@@ -81,13 +84,7 @@ class Results extends Component {
           ) : (
             <div className="results__list">
               <div className="results__top-bar">
-                {results.length
-                  ? `Showing ${
-                      resultsPerPage < totalResults
-                        ? resultsPerPage
-                        : totalResults
-                    } of ${totalResults} results`
-                  : null}
+                {results.length ? <NumberOfResults /> : null}
                 {results.filter(result => !dataSet[result.accession_code])
                   .length === 0 ? (
                   <RemoveFromDatasetButton
@@ -127,3 +124,35 @@ class Results extends Component {
 }
 
 export default Results;
+
+const PAGE_SIZES = [10, 20, 50];
+
+let NumberOfResults = ({
+  resultsPerPage,
+  totalResults,
+  updateResultsPerPage
+}) =>
+  // Only show the dropdown if there're enough elements
+  totalResults < PAGE_SIZES[0] ? (
+    <div>
+      Showing {totalResults} of {totalResults} results
+    </div>
+  ) : (
+    <div>
+      Showing
+      <Dropdown
+        options={PAGE_SIZES}
+        selectedOption={resultsPerPage}
+        onChange={updateResultsPerPage}
+      />{' '}
+      of {totalResults} results
+    </div>
+  );
+NumberOfResults = connect(
+  ({
+    search: {
+      pagination: { totalPages, totalResults, resultsPerPage, currentPage }
+    }
+  }) => ({ totalResults, resultsPerPage }),
+  { updateResultsPerPage }
+)(NumberOfResults);

--- a/src/containers/Results/Results.js
+++ b/src/containers/Results/Results.js
@@ -56,7 +56,7 @@ class Results extends Component {
       searchTerm,
       dataSet,
       isLoading,
-      pagination: { totalPages, totalResults, resultsPerPage, currentPage }
+      pagination: { totalPages, currentPage }
     } = this.props;
 
     const totalSamplesOnPage = results.reduce(
@@ -149,10 +149,9 @@ let NumberOfResults = ({
     </div>
   );
 NumberOfResults = connect(
-  ({
-    search: {
-      pagination: { totalPages, totalResults, resultsPerPage, currentPage }
-    }
-  }) => ({ totalResults, resultsPerPage }),
+  ({ search: { pagination: { totalResults, resultsPerPage } } }) => ({
+    totalResults,
+    resultsPerPage
+  }),
   { updateResultsPerPage }
 )(NumberOfResults);

--- a/src/state/search/actions.js
+++ b/src/state/search/actions.js
@@ -154,12 +154,25 @@ export function toggledFilter(filterType, filterValue) {
 }
 
 export function getPage(pageNum) {
-  return (dispatch, getState) => {
+  return async (dispatch, getState) => {
     dispatch({
       type: 'SEARCH_GET_PAGE'
     });
     const { searchTerm } = getState().search;
 
-    dispatch(fetchResults(searchTerm, parseInt(pageNum, 10)));
+    await dispatch(fetchResults(searchTerm, parseInt(pageNum, 10)));
   };
 }
+
+export const updateResultsPerPage = resultsPerPage => async (
+  dispatch,
+  getState
+) => {
+  dispatch({
+    type: 'UPDATE_PAGE_SIZE',
+    data: resultsPerPage
+  });
+  const { searchTerm } = getState().search;
+
+  await dispatch(fetchResults(searchTerm));
+};

--- a/src/state/search/reducer.js
+++ b/src/state/search/reducer.js
@@ -88,6 +88,16 @@ export default (state = initialState, action) => {
         }
       };
     }
+    case 'UPDATE_PAGE_SIZE': {
+      const resultsPerPage = action.data;
+      return {
+        ...state,
+        pagination: {
+          ...state.pagination,
+          resultsPerPage
+        }
+      };
+    }
     default:
       return state;
   }


### PR DESCRIPTION
## Issue Number

Close #18 

## Purpose/Implementation Notes

Adds a dropdown to allow the user to change the number of results returned in the search. The dropdown is only displayed if there're more than 10 results for the search.

## Types of changes

* [x] New feature (non-breaking change which adds functionality)

## Functional tests

- Changes the values in the dropdown, and checked that the results were refreshed.

## Screenshots

![image](https://user-images.githubusercontent.com/1882507/41064425-7ba5191e-69a9-11e8-9229-f774ab557006.png)

