### PR TITLE
Arielsvn/support/25 download file summary

### DIFF
--- a/src/containers/Downloads/DownloadFileSummary.js
+++ b/src/containers/Downloads/DownloadFileSummary.js
@@ -5,7 +5,7 @@ const DownloadFileSummary = ({ summaryData }) => {
     <section className="downloads__section">
       <h2>Download Files Summary</h2>
       <div className="downloads__cards">
-        {summaryData.map((card, i) => (
+        {summaryData.files.map((card, i) => (
           <div className="downloads__card" key={i}>
             <h4>{card.title}</h4>
             <p>{card.description}</p>
@@ -15,6 +15,11 @@ const DownloadFileSummary = ({ summaryData }) => {
             </div>
           </div>
         ))}
+
+        <div className="downloads__card">
+          <h4>Estimated Download Size</h4>
+          <h4>{summaryData.total}</h4>
+        </div>
       </div>
     </section>
   );

--- a/src/containers/Downloads/Downloads.scss
+++ b/src/containers/Downloads/Downloads.scss
@@ -37,6 +37,10 @@
     padding: 18px 0;
     text-align: center;
 
+    display: flex;
+    flex-direction: column;
+    justify-content: center;  
+
     &--summary {
       padding-left: 1.5rem;
       padding-right: 1.5rem;

--- a/src/containers/Downloads/ViewDownload.js
+++ b/src/containers/Downloads/ViewDownload.js
@@ -10,6 +10,7 @@ import {
   getExperimentCountBySpecies,
   getTotalExperimentsAdded
 } from '../../state/download/reducer';
+import downloadsFilesData from './downloadFilesData';
 
 /**
  * This page is displayed when the user views a download that is different from the one that's
@@ -37,7 +38,7 @@ ViewDownload = connect(
     dataSet,
     experiments,
     dataSetId: ownProps.match.params.id,
-    filesData: downloadFilesData,
+    filesData: downloadsFilesData(dataSet),
     samplesBySpecies:
       samples && dataSet
         ? groupSamplesBySpecies({
@@ -59,30 +60,3 @@ ViewDownload = connect(
 )(ViewDownload);
 
 export default ViewDownload;
-
-const downloadFilesData = [
-  {
-    title: '13 Gene Expression Matrices',
-    description: '1 file per Aggregation Choice',
-    size: '21 MB',
-    format: 'csv'
-  },
-  {
-    title: '13 Sample Metadata Files',
-    description: '1 file per Experiment',
-    size: '26 MB',
-    format: 'txt'
-  },
-  {
-    title: '13 Quality Reports',
-    description: '1 file per Experiment',
-    size: '13 MB',
-    format: 'html'
-  },
-  {
-    title: 'Estimated Download Size',
-    description: ' ',
-    size: '60 MB',
-    format: ''
-  }
-];

--- a/src/containers/Downloads/downloadFilesData.js
+++ b/src/containers/Downloads/downloadFilesData.js
@@ -1,0 +1,112 @@
+/**
+ * Returns file information estimations for a dataset, used as a helper method for the downloads page
+ * ref: https://github.com/AlexsLemonade/refinebio-frontend/issues/25#issuecomment-395870627
+ */
+export default function downloadsFilesData(dataSet) {
+  const totalExperiments = Object.keys(dataSet).length;
+  const geneExpressionSize = estimateGeneExpressionSize(dataSet);
+  const sampleMetadataSize = estimateSampleMetadataSize(dataSet);
+  const qualityReportSize = estimateExperimentMetadataSize(dataSet);
+
+  const allMetadataFileSize = sampleMetadataSize + qualityReportSize;
+
+  const totalSize =
+    geneExpressionSize +
+    sampleMetadataSize +
+    qualityReportSize +
+    allMetadataFileSize;
+
+  const data = {
+    total: formatBytes(totalSize),
+    files: [
+      {
+        title: `${totalExperiments} Gene Expression Matrices`,
+        description: '1 file per Experiment',
+        size: formatBytes(geneExpressionSize),
+        format: 'PCL'
+      },
+      {
+        title: `${totalExperiments} Sample Metadata Files`,
+        description: '1 file per Experiment',
+        size: formatBytes(sampleMetadataSize),
+        format: 'tsv'
+      },
+      {
+        title: `${totalExperiments} Quality Reports`,
+        description: '1 file per Experiment',
+        size: formatBytes(qualityReportSize),
+        format: 'html'
+      }
+    ]
+  };
+
+  return data;
+}
+
+// TODO
+function sampleMetadata(sampleId) {
+  const SAMPLE_SIZE = 1024;
+  return SAMPLE_SIZE;
+}
+
+// TODO add correct estimate for the matrix of a sample
+function estimateMatrixSizeOfSample(sampleId) {
+  return 20 * 256;
+}
+
+/**
+ * Estimate the gene experssion matrix file sizes for a given dataset, this code was written using
+ * https://github.com/AlexsLemonade/refinebio-frontend/issues/25#issue-324513980
+ * as a guidance.
+ */
+function estimateGeneExpressionSize(dataSet) {
+  let totalSize = 0;
+
+  // calculate the size of each one of the experiments
+  for (let experimentId of Object.keys(dataSet)) {
+    let experimentSamples = dataSet[experimentId];
+    // Need size of gene column for the first matrix.
+    let experimentSize = 0.5 * estimateMatrixSizeOfSample(experimentSamples[0]);
+    for (let sampleId of experimentSamples) {
+      // Need size of value column for every sample.
+      let experimentSize =
+        experimentSize + 0.5 * estimateMatrixSizeOfSample(experimentSamples[0]);
+    }
+    totalSize = totalSize + experimentSize;
+  }
+
+  return totalSize;
+}
+
+function estimateSampleMetadataSize(dataSet) {
+  let result = 0;
+  // Count the total number of samples, and multiply it with the average sample size
+  for (let experimentId of Object.keys(dataSet)) {
+    let experimentSamples = dataSet[experimentId];
+    for (let sampleId of experimentSamples) {
+      result = result + sampleMetadata(sampleId);
+    }
+  }
+  return result;
+}
+
+function estimateExperimentMetadataSize(dataSet) {
+  // TODO Estimated size of experiment metadata file
+  const EXPERIMENT_SIZE = 2024;
+  return Object.keys(dataSet).length * EXPERIMENT_SIZE;
+}
+
+/**
+ * String formatting of file size
+ * thanks to https://stackoverflow.com/a/18650828/763705
+ * @param {*} bytes
+ * @param {*} decimals
+ */
+function formatBytes(bytes, decimals = 2) {
+  if (bytes == 0) return '0 Bytes';
+  let k = 1024,
+    dm = decimals,
+    sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'],
+    i = Math.floor(Math.log(bytes) / Math.log(k));
+  return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i];
+}

--- a/src/containers/Downloads/downloadFilesData.js
+++ b/src/containers/Downloads/downloadFilesData.js
@@ -32,10 +32,10 @@ export default function downloadsFilesData(dataSet) {
         format: 'tsv'
       },
       {
-        title: `${totalExperiments} Quality Reports`,
+        title: `${totalExperiments} Experiment Metadata Files`,
         description: '1 file per Experiment',
         size: formatBytes(qualityReportSize),
-        format: 'html'
+        format: 'json'
       }
     ]
   };
@@ -43,9 +43,9 @@ export default function downloadsFilesData(dataSet) {
   return data;
 }
 
-// TODO
+// TODO add a better estimation of the size of each sample metadata
 function sampleMetadata(sampleId) {
-  const SAMPLE_SIZE = 1024;
+  const SAMPLE_SIZE = 5 * 1024;
   return SAMPLE_SIZE;
 }
 
@@ -92,7 +92,7 @@ function estimateSampleMetadataSize(dataSet) {
 
 function estimateExperimentMetadataSize(dataSet) {
   // TODO Estimated size of experiment metadata file
-  const EXPERIMENT_SIZE = 2024;
+  const EXPERIMENT_SIZE = 4048;
   return Object.keys(dataSet).length * EXPERIMENT_SIZE;
 }
 

--- a/src/containers/Downloads/index.js
+++ b/src/containers/Downloads/index.js
@@ -16,6 +16,7 @@ import {
 import DownloadBar from './DownloadBar';
 import DownloadDetails from './DownloadDetails';
 import './Downloads.scss';
+import downloadsFilesData from './downloadFilesData';
 
 class Download extends Component {
   componentDidMount() {
@@ -75,7 +76,7 @@ Download = connect(
       samples: samples,
       dataSet: dataSet
     }),
-    filesData: downloadFilesData,
+    filesData: downloadsFilesData(dataSet),
     totalSamples: getTotalSamplesAdded({ dataSet }),
     totalExperiments: getTotalExperimentsAdded({ dataSet }),
     experimentCountBySpecies: getExperimentCountBySpecies({
@@ -91,30 +92,3 @@ Download = connect(
 )(Download);
 
 export default Download;
-
-const downloadFilesData = [
-  {
-    title: '13 Gene Expression Matrices',
-    description: '1 file per Aggregation Choice',
-    size: '21 MB',
-    format: 'csv'
-  },
-  {
-    title: '13 Sample Metadata Files',
-    description: '1 file per Experiment',
-    size: '26 MB',
-    format: 'txt'
-  },
-  {
-    title: '13 Quality Reports',
-    description: '1 file per Experiment',
-    size: '13 MB',
-    format: 'html'
-  },
-  {
-    title: 'Estimated Download Size',
-    description: ' ',
-    size: '60 MB',
-    format: ''
-  }
-];


### PR DESCRIPTION
## Issue Number

Close #25 

## Purpose/Implementation Notes

Adds helper methods to estimate the sizes of the files in a download.

There're three constants that now have rough estimates, and should be updated to get more accurate results.

- Size of Gene expression matrix of a sample
- Size of a single Sample Metadata
- Size of a single Experiment Metadata

## Types of changes

* [x] New feature (non-breaking change which adds functionality)

## Functional tests

Checked the download page with several combinations of samples.

## Screenshots

![image](https://user-images.githubusercontent.com/1882507/41242962-fee04042-6d6e-11e8-8d3d-de19207d6e68.png)

![image](https://user-images.githubusercontent.com/1882507/41242991-10689b66-6d6f-11e8-9d8b-131dd9426365.png)

