### PR TITLE
Add summary stats placeholder to landing page

### DIFF
--- a/src/containers/Main/Main.scss
+++ b/src/containers/Main/Main.scss
@@ -126,4 +126,12 @@
     color: $azure;
     border: none;
   }
+
+  &__stats-placeholder {
+    margin-top: 50px;
+    margin-left: auto;
+    display: block;
+    margin-right: auto;
+    max-width: 100%;
+  }
 }

--- a/src/containers/Main/index.js
+++ b/src/containers/Main/index.js
@@ -77,13 +77,15 @@ const Main = ({ searchTerm, fetchResults, push }) => {
           </div>
         </div>
       </section>
-      <section className="main__section main__section--gray">
-        <div className="main__container">
-          <h2 className="main__heading-1">Summary Statistics</h2>
+      {false && (
+        <section className="main__section main__section--gray">
+          <div className="main__container">
+            <h2 className="main__heading-1">Summary Statistics</h2>
 
-          <img src={StatsPlaceholder} class="main__stats-placeholder" />
-        </div>
-      </section>
+            <img src={StatsPlaceholder} class="main__stats-placeholder" />
+          </div>
+        </section>
+      )}
       <section className="main__section main__section--blue-gradient">
         <div className="main__container">
           <h1 className="main__heading-1">Sign Up for Updates</h1>

--- a/src/containers/Main/index.js
+++ b/src/containers/Main/index.js
@@ -7,6 +7,7 @@ import { Link } from 'react-router-dom';
 import SearchIcon from '../../common/icons/search.svg';
 import DatasetIcon from '../../common/icons/dataset.svg';
 import './Main.scss';
+import StatsPlaceholder from './summary-stats-placeholder.svg';
 
 const Main = ({ searchTerm, fetchResults, push }) => {
   return (
@@ -79,6 +80,8 @@ const Main = ({ searchTerm, fetchResults, push }) => {
       <section className="main__section main__section--gray">
         <div className="main__container">
           <h2 className="main__heading-1">Summary Statistics</h2>
+
+          <img src={StatsPlaceholder} class="main__stats-placeholder" />
         </div>
       </section>
       <section className="main__section main__section--blue-gradient">

--- a/src/containers/Main/summary-stats-placeholder.svg
+++ b/src/containers/Main/summary-stats-placeholder.svg
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="828px" height="497px" viewBox="0 0 828 497" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 50.2 (55047) - http://www.bohemiancoding.com/sketch -->
+    <title>undraw_charts_jj6t (1)</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Landing-Page" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="landing-page" transform="translate(-333.000000, -1308.000000)" fill-rule="nonzero">
+            <g id="summary-stats-section" transform="translate(0.000000, 1069.000000)">
+                <g id="undraw_charts_jj6t-(1)" transform="translate(333.000000, 239.000000)">
+                    <rect id="Rectangle-path" fill="#FFFFFF" x="0" y="0" width="828" height="497"></rect>
+                    <rect id="Rectangle-path" fill="#F5F5F5" x="105" y="78" width="59" height="354"></rect>
+                    <rect id="Rectangle-path" fill="#F5F5F5" x="258" y="78" width="59" height="354"></rect>
+                    <rect id="Rectangle-path" fill="#F5F5F5" x="387" y="81" width="59" height="354"></rect>
+                    <rect id="Rectangle-path" fill="#F5F5F5" x="544" y="81" width="59" height="354"></rect>
+                    <rect id="Rectangle-path" fill="#2196F3" x="105" y="255" width="59" height="177"></rect>
+                    <g id="Group" opacity="0.4" transform="translate(105.000000, 181.000000)" fill="#2196F3">
+                        <rect id="Rectangle-path" x="0" y="0" width="59" height="77"></rect>
+                    </g>
+                    <rect id="Rectangle-path" fill="#69F0AE" x="258.007473" y="292.412237" width="58.5419898" height="138.533461"></rect>
+                    <rect id="Rectangle-path" fill="#69F0AE" opacity="0.4" x="258.007473" y="203.080144" width="58.5419898" height="89.9505456"></rect>
+                    <rect id="Rectangle-path" fill="#386DB0" x="387" y="232" width="59" height="203"></rect>
+                    <rect id="Rectangle-path" fill="#386DB0" opacity="0.4" x="387" y="162" width="59" height="70"></rect>
+                    <rect id="Rectangle-path" fill="#FFFF00" x="544" y="303" width="59" height="132"></rect>
+                    <rect id="Rectangle-path" fill="#FFFF00" opacity="0.4" x="544" y="261" width="59" height="41"></rect>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>


### PR DESCRIPTION
## Issue Number

#64 

## Purpose/Implementation Notes

Add placeholder image with summary statics to the landing page.

## Screenshots

![image](https://user-images.githubusercontent.com/1882507/41244170-3e1fa4ca-6d72-11e8-9f45-869bd59a35c3.png)

