### PR TITLE
Arielsvn/support/72 back to search

### DIFF
--- a/src/common/helpers.js
+++ b/src/common/helpers.js
@@ -16,6 +16,10 @@ export function getQueryString(queryObj) {
  * @returns {object}
  */
 export function getQueryParamObject(queryString) {
+  if (queryString.startsWith('?')) {
+    queryString = queryString.substr(1);
+  }
+
   const queryObj = {};
   queryString.split('&').forEach(queryParam => {
     const [key, value] = queryParam.split('=');

--- a/src/containers/Experiment/index.js
+++ b/src/containers/Experiment/index.js
@@ -4,7 +4,7 @@ import { bindActionCreators } from 'redux';
 import Loader from '../../components/Loader';
 import { fetchExperiment } from '../../state/experiment/actions';
 import Button from '../../components/Button';
-
+import { getQueryParamObject } from '../../common/helpers';
 import './Experiment.scss';
 
 import AccessionIcon from '../../common/icons/accession.svg';
@@ -21,6 +21,8 @@ import {
 } from '../../state/download/actions';
 import { RemoveFromDatasetButton } from '../Results/Result';
 
+import { goBack } from '../../state/routerActions';
+
 let Experiment = ({
   fetchExperiment,
   experiment,
@@ -29,135 +31,149 @@ let Experiment = ({
   removeSamplesFromExperiment,
   addSamplesToDataset,
   dataSet,
-  match
-}) => (
-  <Loader fetch={() => fetchExperiment(match.params.id)}>
-    {({ isLoading }) =>
-      isLoading ? (
-        <div className="loader" />
-      ) : (
-        <div>
-          <Button text="Back to Results" buttonStyle="secondary" />
+  match,
+  location: { search },
+  goBack
+}) => {
+  // check for the parameter `ref=search` to ensure that the previous page was the search
+  const comesFromSearch = getQueryParamObject(search)['ref'] === 'search';
 
-          <div className="experiment">
-            <div className="experiment__accession">
-              <img
-                src={AccessionIcon}
-                className="experiment__stats-icon"
-                alt="Accession Icon"
+  return (
+    <Loader fetch={() => fetchExperiment(match.params.id)}>
+      {({ isLoading }) =>
+        isLoading ? (
+          <div className="loader" />
+        ) : (
+          <div>
+            {comesFromSearch && (
+              <Button
+                text="Back to Results"
+                buttonStyle="secondary"
+                onClick={goBack}
               />
-              {experiment.accession_code}
-            </div>
+            )}
 
-            <div className="experiment__header">
-              <h3 className="experiment__header-title">
-                {experiment.title || 'No Title.'}
-              </h3>
-              <div>
-                {!dataSet[experiment.accession_code] ? (
-                  <Button
-                    text="Add to Dataset"
-                    onClick={() => addExperiment([experiment])}
-                  />
-                ) : (
-                  <RemoveFromDatasetButton
-                    handleRemove={() =>
-                      removeExperiment([experiment.accession_code])
-                    }
-                    samplesInDataset={
-                      dataSet[experiment.accession_code].length !==
-                      experiment.samples.length
-                        ? dataSet[experiment.accession_code].length
-                        : null
-                    }
-                  />
-                )}
-              </div>
-            </div>
-
-            <div className="experiment__stats">
-              <div className="experiment__stats-item">
+            <div className="experiment">
+              <div className="experiment__accession">
                 <img
-                  src={OrganismIcon}
+                  src={AccessionIcon}
                   className="experiment__stats-icon"
-                  alt="Organism Icon"
-                />{' '}
-                {experiment.species}
+                  alt="Accession Icon"
+                />
+                {experiment.accession_code}
               </div>
-              <div className="experiment__stats-item">
-                <img
-                  src={SampleIcon}
-                  className="experiment__stats-icon"
-                  alt="Sample Icon"
-                />{' '}
-                {experiment.samples.length} Samples
-              </div>
-              <div className="experiment__stats-item">
-                <img
-                  src={MicroarrayIcon}
-                  className="experiment__stats-icon"
-                  alt="MicroArray Badge Icon"
-                />{' '}
-                {experiment.id}
-              </div>
-            </div>
 
-            <h4 className="experiment__title">
-              Submitter Supplied Information
-            </h4>
-
-            <div>
-              <div className="experiment__row">
-                <div className="experiment__row-label">Description</div>
-                <div>{experiment.description}</div>
-              </div>
-              <div className="experiment__row">
-                <div className="experiment__row-label">PubMed ID</div>
-                <div>{experiment.pubmed_id}</div>
-              </div>
-              <div className="experiment__row">
-                <div className="experiment__row-label">Publication Title</div>
-                <div>{experiment.publication_title}</div>
-              </div>
-              <div className="experiment__row">
-                <div className="experiment__row-label">
-                  Submitter’s Institution
+              <div className="experiment__header">
+                <h3 className="experiment__header-title">
+                  {experiment.title || 'No Title.'}
+                </h3>
+                <div>
+                  {!dataSet[experiment.accession_code] ? (
+                    <Button
+                      text="Add to Dataset"
+                      onClick={() => addExperiment([experiment])}
+                    />
+                  ) : (
+                    <RemoveFromDatasetButton
+                      handleRemove={() =>
+                        removeExperiment([experiment.accession_code])
+                      }
+                      samplesInDataset={
+                        dataSet[experiment.accession_code].length !==
+                        experiment.samples.length
+                          ? dataSet[experiment.accession_code].length
+                          : null
+                      }
+                    />
+                  )}
                 </div>
-                <div>{experiment.submitter_institution}</div>
               </div>
-              <div className="experiment__row">
-                <div className="experiment__row-label">Submitter</div>
-                <div>{experiment.pubmed_id}</div>
-              </div>
-            </div>
 
-            <Anchor name="samples">
-              {() => (
-                <section className="experiment__section">
-                  <h2 className="experiment__title">Samples</h2>
-                  <SamplesTable
-                    sampleIds={experiment.samples.map(x => x.id)}
-                    // Render prop for the button that adds the samples to the dataset
-                    pageActionComponent={samplesDisplayed => (
-                      <SampleTableActions samples={samplesDisplayed} />
-                    )}
-                  />
-                </section>
-              )}
-            </Anchor>
+              <div className="experiment__stats">
+                <div className="experiment__stats-item">
+                  <img
+                    src={OrganismIcon}
+                    className="experiment__stats-icon"
+                    alt="Organism Icon"
+                  />{' '}
+                  {experiment.species}
+                </div>
+                <div className="experiment__stats-item">
+                  <img
+                    src={SampleIcon}
+                    className="experiment__stats-icon"
+                    alt="Sample Icon"
+                  />{' '}
+                  {experiment.samples.length} Samples
+                </div>
+                <div className="experiment__stats-item">
+                  <img
+                    src={MicroarrayIcon}
+                    className="experiment__stats-icon"
+                    alt="MicroArray Badge Icon"
+                  />{' '}
+                  {experiment.id}
+                </div>
+              </div>
+
+              <h4 className="experiment__title">
+                Submitter Supplied Information
+              </h4>
+
+              <div>
+                <div className="experiment__row">
+                  <div className="experiment__row-label">Description</div>
+                  <div>{experiment.description}</div>
+                </div>
+                <div className="experiment__row">
+                  <div className="experiment__row-label">PubMed ID</div>
+                  <div>{experiment.pubmed_id}</div>
+                </div>
+                <div className="experiment__row">
+                  <div className="experiment__row-label">Publication Title</div>
+                  <div>{experiment.publication_title}</div>
+                </div>
+                <div className="experiment__row">
+                  <div className="experiment__row-label">
+                    Submitter’s Institution
+                  </div>
+                  <div>{experiment.submitter_institution}</div>
+                </div>
+                <div className="experiment__row">
+                  <div className="experiment__row-label">Submitter</div>
+                  <div>{experiment.pubmed_id}</div>
+                </div>
+              </div>
+
+              <Anchor name="samples">
+                {() => (
+                  <section className="experiment__section">
+                    <h2 className="experiment__title">Samples</h2>
+                    <SamplesTable
+                      sampleIds={experiment.samples.map(x => x.id)}
+                      // Render prop for the button that adds the samples to the dataset
+                      pageActionComponent={samplesDisplayed => (
+                        <SampleTableActions samples={samplesDisplayed} />
+                      )}
+                    />
+                  </section>
+                )}
+              </Anchor>
+            </div>
           </div>
-        </div>
-      )
-    }
-  </Loader>
-);
+        )
+      }
+    </Loader>
+  );
+};
 Experiment = connect(
   ({ experiment, download: { dataSet } }) => ({ experiment, dataSet }),
   {
     fetchExperiment,
     addExperiment,
     removeExperiment,
-    removeSamplesFromExperiment
+    removeSamplesFromExperiment,
+    goBack
   }
 )(Experiment);
 

--- a/src/containers/Results/Result/index.js
+++ b/src/containers/Results/Result/index.js
@@ -59,7 +59,7 @@ const Result = ({ result, addExperiment, removeExperiment, dataSet }) => {
           </div>
           <Link
             className="button button--link"
-            to={`/experiments/${result.id}`}
+            to={`/experiments/${result.id}?ref=search`}
           >
             <h2 className="result__title">{result.title || 'No title.'}</h2>
           </Link>
@@ -108,7 +108,7 @@ const Result = ({ result, addExperiment, removeExperiment, dataSet }) => {
 
       <Link
         className="button button--secondary"
-        to={`/experiments/${result.id}#samples`}
+        to={`/experiments/${result.id}?ref=search#samples`}
       >
         View Samples
       </Link>


### PR DESCRIPTION
## Issue Number

close #72 

## Purpose/Implementation Notes

Show back to search button on Experiment page, only when the user comes from the search results.

## Types of changes

* [x] New feature (non-breaking change which adds functionality)

## Functional tests

- Open experiments page directly -> no back to search button
- navigate to experiments page from search page

## Screenshots

![image](https://user-images.githubusercontent.com/1882507/41245520-347dbe76-6d76-11e8-8198-2bee3a5794a1.png)

![image](https://user-images.githubusercontent.com/1882507/41245541-451abd24-6d76-11e8-99b0-0839e72806fa.png)
