### PR TITLE
Kurtwheeler/continuous deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,9 +5,11 @@ jobs:
       - image: circleci/python:3-node
     steps:
       - checkout
-      - run: pip install awscli --upgrade --user
       - run: yarn install --ignore-engines
 
       # TODO: Maybe fix this? Or at least delete this comment
       - run: CI=false yarn run build
-      - run: aws s3 sync build s3://$AWS_S3_BUCKET_PATH --delete
+      - run: pip install awscli --upgrade --user
+
+      # I'm not sure why it installs here but it does...
+      - run: ~/.local/bin/aws s3 sync build s3://$AWS_S3_BUCKET_PATH --delete

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,3 +22,5 @@ workflows:
           filters:
             branches:
               only: master
+            tags:
+              only: /v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2
 jobs:
   build:
-    machine: true
-    working_directory: ~/refinebio-frontend
+    docker:
+      - image: circleci/node
     steps:
       - checkout
       - run: yarn install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,5 +7,7 @@ jobs:
       - checkout
       - run: pip install awscli --upgrade --user
       - run: yarn install --ignore-engines
-      - run: yarn run build
+
+      # TODO: Maybe fix this? Or at least delete this comment
+      - run: CI=false yarn run build
       - run: aws s3 sync build s3://$AWS_S3_BUCKET_PATH --delete

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,3 @@
-# Circle's onboarding is ANNOYING!!
 version: 2
 jobs:
   deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2
 jobs:
-  build:
+  deploy:
     docker:
       - image: circleci/python:3-node
     steps:
@@ -13,3 +13,12 @@ jobs:
 
       # I'm not sure why it installs here but it does...
       - run: ~/.local/bin/aws s3 sync build s3://staging.refine.bio --delete --acl public-read
+
+workflows:
+  version: 2
+  deploy:
+    jobs:
+      - deploy:
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,4 +12,4 @@ jobs:
       - run: pip install awscli --upgrade --user
 
       # I'm not sure why it installs here but it does...
-      - run: ~/.local/bin/aws s3 sync build s3://$AWS_S3_BUCKET_PATH --delete
+      - run: ~/.local/bin/aws s3 sync build s3://staging.refine.bio --delete

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       - run: yarn install --ignore-engines
 
       # TODO: Maybe fix this? Or at least delete this comment
-      - run: CI=false yarn run build
+      - run: CI=false REACT_APP_API_HOST=http://api.staging.refine.bio yarn run build
       - run: pip install awscli --upgrade --user
 
       # I'm not sure why it installs here but it does...

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,4 +12,4 @@ jobs:
       - run: pip install awscli --upgrade --user
 
       # I'm not sure why it installs here but it does...
-      - run: ~/.local/bin/aws s3 sync build s3://staging.refine.bio --delete
+      - run: ~/.local/bin/aws s3 sync build s3://staging.refine.bio --delete --acl public-read

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,9 +2,10 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node
+      - image: circleci/python:3-node
     steps:
       - checkout
-      - run: yarn install
+      - run: pip install awscli --upgrade --user
+      - run: yarn install --ignore-engines
       - run: yarn run build
       - run: aws s3 sync build s3://$AWS_S3_BUCKET_PATH --delete

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2
 jobs:
-  deploy:
+  build:
     machine: true
     working_directory: ~/refinebio-frontend
     steps:

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,4 @@
+# Circle's onboarding is ANNOYING!!
 version: 2
 jobs:
   deploy:

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,10 @@
+version: 2
+jobs:
+  deploy:
+    machine: true
+    working_directory: ~/refinebio-frontend
+    steps:
+      - checkout
+      - run: yarn install
+      - run: yarn run build
+      - run: aws s3 sync build s3://$AWS_S3_BUCKET_PATH --delete


### PR DESCRIPTION
## Issue Number

#5 

## Purpose/Implementation Notes

This sets up continuous deployment for the front end. Any time a branch is merged into master with a tag starting with a `v` (as in version) we will rebuild and deploy the frontend. This way we can only deploy version commits.

## Types of changes

* [x] New feature (non-breaking change which adds functionality)

## Functional tests

I let the build run before adding the filters so that it would only happen on version-tagged commits to master: https://circleci.com/gh/AlexsLemonade/refinebio-frontend/11
