### PR TITLE
get api root via env variables

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,1 @@
+REACT_APP_API_HOST=http://localhost:8000

--- a/src/common/helpers.js
+++ b/src/common/helpers.js
@@ -50,7 +50,10 @@ export function getRange(n) {
  * @returns {Promise}
  */
 export async function asyncFetch(url, params) {
-  const response = await fetch(url, params);
+  const response = await fetch(
+    `${process.env.REACT_APP_API_HOST}${url}`,
+    params
+  );
 
   /**
    * You only get an exception (rejection) when there's a network problem.


### PR DESCRIPTION
## Issue Number
Closes #86 

## Purpose/Implementation Notes
* Set the API root based on environment
* This does result in CORS issues, so CORS will have to be enabled on the API side of things

This was a helpful resource: https://daveceddia.com/multiple-environments-with-react/

## Types of changes

What types of changes does your code introduce?
* [x] New feature (non-breaking change which adds functionality)

## Functional tests
* Running the build with a specific `REACT_APP_API_HOST` env variable set updates the API to use that root
