### PR TITLE
Ramenhog/update/77 accession codes ids swap

### DIFF
--- a/src/api/dataSet.js
+++ b/src/api/dataSet.js
@@ -21,7 +21,7 @@ export async function getSamplesAndExperiments(dataSet) {
       const { samples: sampleList } = experimentInfo;
       const response = await Ajax.get('/samples/', {
         limit: 1000000000000000,
-        ids: sampleList.join(',')
+        accession_codes: sampleList.join(',')
       });
       const sampleInfo = response.results;
 

--- a/src/api/samples.js
+++ b/src/api/samples.js
@@ -15,10 +15,15 @@ export async function getDetailedSample(sampleId) {
  * @param {number} offset
  * @param {number} limit
  */
-export async function getAllDetailedSamples({ ids, orderBy, offset, limit }) {
-  if (ids && ids.length) {
+export async function getAllDetailedSamples({
+  accessionCodes,
+  orderBy,
+  offset,
+  limit
+}) {
+  if (accessionCodes && accessionCodes.length) {
     let { results } = await Ajax.get('/samples/', {
-      ids,
+      accession_codes: accessionCodes,
       offset,
       limit,
       order_by: orderBy

--- a/src/containers/Downloads/DownloadDetails.js
+++ b/src/containers/Downloads/DownloadDetails.js
@@ -83,7 +83,9 @@ const SpeciesSamples = ({ samplesBySpecies, removeSpecies }) => {
           modalProps={{ className: 'samples-modal' }}
         >
           {() => (
-            <SamplesTable sampleIds={species[speciesName].map(x => x.id)} />
+            <SamplesTable
+              accessionCodes={species[speciesName].map(x => x.accession_code)}
+            />
           )}
         </ModalManager>
       </div>
@@ -150,7 +152,7 @@ const ExperimentsView = ({ dataSet, experiments, removeExperiment }) => {
               )}
               modalProps={{ className: 'samples-modal' }}
             >
-              {() => <SamplesTable sampleIds={experiment.samples} />}
+              {() => <SamplesTable accessionCodes={experiment.samples} />}
             </ModalManager>
           )}
         </div>

--- a/src/containers/Experiment/SamplesTable.js
+++ b/src/containers/Experiment/SamplesTable.js
@@ -24,7 +24,7 @@ export default class SamplesTable extends React.Component {
   };
 
   get totalSamples() {
-    return this.props.sampleIds.length;
+    return this.props.accessionCodes.length;
   }
 
   render() {
@@ -79,7 +79,7 @@ export default class SamplesTable extends React.Component {
   }
 
   fetchData = async (tableState = false) => {
-    const sampleIds = this.props.sampleIds;
+    const accessionCodes = this.props.accessionCodes;
     const { page, pageSize } = this.state;
     // get the backend ready `order_by` param, based on the sort options from the table
     let orderBy = this._getSortParam(tableState);
@@ -89,7 +89,7 @@ export default class SamplesTable extends React.Component {
     let offset = page * pageSize;
 
     const data = await getAllDetailedSamples({
-      ids: sampleIds,
+      accessionCodes,
       orderBy,
       offset,
       limit: pageSize

--- a/src/containers/Experiment/index.js
+++ b/src/containers/Experiment/index.js
@@ -150,7 +150,9 @@ let Experiment = ({
                   <section className="experiment__section">
                     <h2 className="experiment__title">Samples</h2>
                     <SamplesTable
-                      sampleIds={experiment.samples.map(x => x.id)}
+                      accessionCodes={experiment.samples.map(
+                        x => x.accession_code
+                      )}
                       // Render prop for the button that adds the samples to the dataset
                       pageActionComponent={samplesDisplayed => (
                         <SampleTableActions samples={samplesDisplayed} />

--- a/src/state/download/actions.js
+++ b/src/state/download/actions.js
@@ -45,18 +45,21 @@ export const removeExperimentSucceeded = dataSet => {
   };
 };
 
-export const removeSamplesFromExperiment = (accessionCode, sampleIds) => {
+export const removeSamplesFromExperiment = (
+  accessionCode,
+  sampleAccessions
+) => {
   return async (dispatch, getState) => {
     dispatch({
       type: 'DOWNLOAD_REMOVE_EXPERIMENT',
       data: {
         accessionCode,
-        sampleIds
+        sampleAccessions
       }
     });
     const { dataSet, dataSetId } = getState().download;
     const filteredSamples = dataSet[accessionCode].filter(
-      sample => sampleIds.indexOf(sample) === -1
+      sample => sampleAccessions.indexOf(sample) === -1
     );
     const newDataSet = { ...dataSet };
     if (filteredSamples.length) {
@@ -80,11 +83,11 @@ export const removeSamplesFromExperiment = (accessionCode, sampleIds) => {
  */
 export const removeSpecies = samples => {
   return async (dispatch, getState) => {
-    const sampleIds = samples.map(sample => sample.id);
+    const sampleAccessions = samples.map(sample => sample.accession_code);
     dispatch({
       type: 'DOWNLOAD_REMOVE_SPECIES',
       data: {
-        sampleIds
+        sampleAccessions
       }
     });
 
@@ -94,7 +97,7 @@ export const removeSpecies = samples => {
       const samples = dataSet[accessionCode];
 
       const filteredSamples = samples.filter(sample => {
-        return sampleIds.indexOf(sample) === -1;
+        return sampleAccessions.indexOf(sample) === -1;
       });
       if (filteredSamples.length) result[accessionCode] = filteredSamples;
       return result;
@@ -134,12 +137,12 @@ export const addExperiment = experiments => {
     const prevDataSet = getState().download.dataSet;
     const newExperiments = experiments.reduce((result, experiment) => {
       if (experiment.samples.length) {
-        const sampleIds = experiment.samples.map(sample => sample.id);
+        const sampleAccessions = experiment.samples;
         result[experiment.accession_code] = prevDataSet[
           experiment.accession_code
         ]
-          ? [...prevDataSet[experiment.accession_code], ...sampleIds]
-          : sampleIds;
+          ? [...prevDataSet[experiment.accession_code], ...sampleAccessions]
+          : sampleAccessions;
       }
       return result;
     }, {});


### PR DESCRIPTION
## Issue Number
#77 

## Purpose/Implementation Notes
Updating the code to use `accession_code` instead of `id` to identify samples.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_
* [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests
* Add/remove samples (by experiment and species) still work
* Sample tables still displays correct information on both experiment page level and downloads page level
