### PR TITLE
format organism name

### DIFF
--- a/src/containers/Experiment/index.js
+++ b/src/containers/Experiment/index.js
@@ -4,7 +4,7 @@ import { bindActionCreators } from 'redux';
 import Loader from '../../components/Loader';
 import { fetchExperiment } from '../../state/experiment/actions';
 import Button from '../../components/Button';
-import { getQueryParamObject } from '../../common/helpers';
+import { getQueryParamObject, formatSentenceCase } from '../../common/helpers';
 import './Experiment.scss';
 
 import AccessionIcon from '../../common/icons/accession.svg';
@@ -37,6 +37,7 @@ let Experiment = ({
 }) => {
   // check for the parameter `ref=search` to ensure that the previous page was the search
   const comesFromSearch = getQueryParamObject(search)['ref'] === 'search';
+  const { organisms = [] } = experiment;
 
   return (
     <Loader fetch={() => fetchExperiment(match.params.id)}>
@@ -96,7 +97,11 @@ let Experiment = ({
                     className="experiment__stats-icon"
                     alt="Organism Icon"
                   />{' '}
-                  {experiment.species}
+                  {organisms.length
+                    ? organisms
+                        .map(organism => formatSentenceCase(organism))
+                        .join(',')
+                    : 'No species.'}
                 </div>
                 <div className="experiment__stats-item">
                   <img

--- a/src/containers/Results/Result/index.js
+++ b/src/containers/Results/Result/index.js
@@ -9,6 +9,7 @@ import './Result.scss';
 import Loader from '../../../components/Loader';
 import { getAllDetailedSamples } from '../../../api/samples';
 import SampleFieldMetadata from '../../Experiment/SampleFieldMetadata';
+import { formatSentenceCase } from '../../../common/helpers';
 
 export function RemoveFromDatasetButton({
   handleRemove,
@@ -84,7 +85,9 @@ const Result = ({ result, addExperiment, removeExperiment, dataSet }) => {
             className="result__icon"
             alt="organism-icon"
           />{' '}
-          {result.organisms.join(',') || 'No species.'}
+          {result.organisms
+            .map(organism => formatSentenceCase(organism))
+            .join(',') || 'No species.'}
         </li>
         <li className="result__stat">
           <img src={SampleIcon} className="result__icon" alt="sample-icon" />{' '}


### PR DESCRIPTION
## Issue Number
Closes #113 

## Purpose/Implementation Notes
* Sentence case organism name so it looks like `Mus musculus` instead of `MUS_MUSCULUS`

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

* [x] Bugfix (non-breaking change which fixes an issue)

## Functional tests
Species now show a human formatted species name on the results factoid bar.

## Screenshots

![screen shot 2018-07-09 at 10 54 58 am](https://user-images.githubusercontent.com/4724065/42457868-8eddf556-8366-11e8-8464-b86af742b394.png)
