### PR TITLE
Ramenhog/bugfix/fix the math

### DIFF
--- a/src/api/dataSet.js
+++ b/src/api/dataSet.js
@@ -16,9 +16,11 @@ export async function getSamplesAndExperiments(dataSet) {
 
       experiments[accessionCode] = experiment.results[0];
 
-      // there should only be one result for each experiment response
-      const experimentInfo = experiment.results[0];
-      const { samples: sampleList } = experimentInfo;
+      /*
+      Use sample accessions from dataSet instead of experiment
+      because some experiments may only have a subset of samples added
+      */
+      const sampleList = dataSet[accessionCode];
       const response = await Ajax.get('/samples/', {
         limit: 1000000000000000,
         accession_codes: sampleList.join(',')

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -30,6 +30,7 @@ $default-active-shadow: 0 3px 4px 0 rgba($black, 0.3);
 
   &:disabled,
   &--disabled {
+    cursor: not-allowed;
     background-color: $button-disabled;
 
     &:hover,

--- a/src/containers/Downloads/index.js
+++ b/src/containers/Downloads/index.js
@@ -46,7 +46,7 @@ class Download extends Component {
     return (
       <div className="downloads">
         <h1 className="downloads__heading">Download Dataset</h1>
-        {isLoading && !areDetailsFetched ? (
+        {isLoading ? (
           <div className="loader" />
         ) : !Object.keys(dataSet).length ? (
           <div className="downloads__empty">

--- a/src/containers/Experiment/index.js
+++ b/src/containers/Experiment/index.js
@@ -198,7 +198,7 @@ let SampleTableActions = ({
       handleRemove={() =>
         removeSamplesFromExperiment(
           experiment.accession_code,
-          samples.map(x => x.id)
+          samples.map(x => x.accession_code)
         )
       }
     />
@@ -210,7 +210,7 @@ let SampleTableActions = ({
         addExperiment([
           {
             accession_code: experiment.accession_code,
-            samples: samples
+            samples: samples.map(x => x.accession_code)
           }
         ])
       }
@@ -233,6 +233,6 @@ SampleTableActions = connect(
 function samplesNotInDataSet(samples, accessionCode, dataSet) {
   return samples.filter(x => {
     if (!dataSet[accessionCode]) return true;
-    return dataSet[accessionCode].indexOf(x.id) === -1;
+    return dataSet[accessionCode].indexOf(x.accession_code) === -1;
   });
 }


### PR DESCRIPTION
## Issue Number
Closes #132 and closes #117 

## Purpose/Implementation Notes
Samples were not being added by accession code on the samples table, so that was messing up the species math on the downloads page. This fixes that.

* also changes the cursor for disabled buttons to `not-allowed`

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

* [x] Bugfix (non-breaking change which fixes an issue)

## Functional tests
* Adding a subset of samples from an experiment on the downloads page shows the correct samples per species and total samples/experiments.
