### PR TITLE
Ramenhog/feature/add remove samples table

### DIFF
--- a/src/containers/Downloads/DownloadDetails.js
+++ b/src/containers/Downloads/DownloadDetails.js
@@ -157,7 +157,12 @@ const ExperimentsView = ({ dataSet, experiments, removeExperiment }) => {
               )}
               modalProps={{ className: 'samples-modal' }}
             >
-              {() => <SamplesTable accessionCodes={experiment.samples} />}
+              {() => (
+                <SamplesTable
+                  accessionCodes={experiment.samples}
+                  experimentAccessionCode={experiment.accession_code}
+                />
+              )}
             </ModalManager>
           )}
         </div>

--- a/src/containers/Downloads/DownloadDetails.js
+++ b/src/containers/Downloads/DownloadDetails.js
@@ -87,6 +87,7 @@ const SpeciesSamples = ({ samplesBySpecies, removeSpecies }) => {
         >
           {() => (
             <SamplesTable
+              isRowRemovable={true}
               accessionCodes={species[speciesName].map(x => x.accession_code)}
               experimentAccessionCodes={species[speciesName].map(
                 x => x.experimentAccessionCode
@@ -163,6 +164,7 @@ const ExperimentsView = ({ dataSet, experiments, removeExperiment }) => {
             >
               {() => (
                 <SamplesTable
+                  isRowRemovable={true}
                   accessionCodes={addedSamples}
                   experimentAccessionCodes={[experiment.accession_code]}
                 />

--- a/src/containers/Downloads/DownloadDetails.js
+++ b/src/containers/Downloads/DownloadDetails.js
@@ -88,6 +88,9 @@ const SpeciesSamples = ({ samplesBySpecies, removeSpecies }) => {
           {() => (
             <SamplesTable
               accessionCodes={species[speciesName].map(x => x.accession_code)}
+              experimentAccessionCodes={species[speciesName].map(
+                x => x.experimentAccessionCode
+              )}
             />
           )}
         </ModalManager>
@@ -110,6 +113,7 @@ const ExperimentsView = ({ dataSet, experiments, removeExperiment }) => {
   }
 
   return Object.keys(dataSet).map((id, i) => {
+    const addedSamples = dataSet[id];
     const experiment = experiments[id];
     return (
       <div className="downloads__sample" key={i}>
@@ -130,7 +134,7 @@ const ExperimentsView = ({ dataSet, experiments, removeExperiment }) => {
                 className="downloads__sample-icon"
                 alt="Sample Icon"
               />{' '}
-              {experiment.samples.length}
+              {addedSamples.length}
             </div>
             <div className="downloads__sample-stat downloads__sample-stat--experiment">
               <img
@@ -146,7 +150,7 @@ const ExperimentsView = ({ dataSet, experiments, removeExperiment }) => {
           <h4>Sample Metadata Fields</h4>
           <h5>{experiment.metadata ? experiment.metadata.join(', ') : null}</h5>
 
-          {experiment.samples.length > 0 && (
+          {addedSamples.length > 0 && (
             <ModalManager
               component={showModal => (
                 <Button
@@ -159,8 +163,8 @@ const ExperimentsView = ({ dataSet, experiments, removeExperiment }) => {
             >
               {() => (
                 <SamplesTable
-                  accessionCodes={experiment.samples}
-                  experimentAccessionCode={experiment.accession_code}
+                  accessionCodes={addedSamples}
+                  experimentAccessionCodes={[experiment.accession_code]}
                 />
               )}
             </ModalManager>

--- a/src/containers/Experiment/SamplesTable.js
+++ b/src/containers/Experiment/SamplesTable.js
@@ -177,7 +177,7 @@ class SamplesTable extends React.Component {
         Header: 'Add/Remove',
         id: 'add_remove',
         Cell: AddRemoveCell.bind(this),
-        minWidth: 200,
+        width: 190,
         className: 'samples-table__add-remove'
       },
       {

--- a/src/containers/Experiment/SamplesTable.js
+++ b/src/containers/Experiment/SamplesTable.js
@@ -21,7 +21,7 @@ import {
 
 import './SamplesTable.scss';
 
-export default class SamplesTable extends React.Component {
+class SamplesTable extends React.Component {
   state = {
     page: 0,
     pages: -1,
@@ -163,8 +163,9 @@ export default class SamplesTable extends React.Component {
       {
         Header: 'Add/Remove',
         id: 'add_remove',
-        Cell: AddRemoveCell,
-        minWidth: 250
+        Cell: AddRemoveCell.bind(this),
+        minWidth: 155,
+        className: 'samples-table__add-remove'
       },
       {
         id: 'id',
@@ -620,18 +621,46 @@ function TxtimportProtocol() {
   );
 }
 
-let AddRemoveCell = props => {
-  console.log(props);
-  const { original: sample } = props;
+function AddRemoveCell({ original: sample }) {
+  const { experimentAccessionCode, accession_code } = sample;
+  const { addExperiment, removeSamplesFromExperiment, dataSet } = this.props;
+  const isAdded =
+    dataSet[experimentAccessionCode] &&
+    dataSet[experimentAccessionCode].includes(accession_code);
+
+  if (!isAdded) {
+    return (
+      <Button
+        buttonStyle="secondary"
+        onClick={() =>
+          addExperiment([
+            {
+              accession_code: experimentAccessionCode,
+              samples: [accession_code]
+            }
+          ])
+        }
+      >
+        Add to Dataset
+      </Button>
+    );
+  }
 
   return (
-    <Button buttonStyle="secondary" onClick={() => {}}>
-      {JSON.stringify(sample)}
-    </Button>
+    <RemoveFromDatasetButton
+      handleRemove={() =>
+        removeSamplesFromExperiment(experimentAccessionCode, [accession_code])
+      }
+    />
   );
-};
+}
 
-AddRemoveCell = connect((state, ownProps) => ({ ...ownProps }), {
-  addExperiment,
-  removeSamplesFromExperiment
-})(AddRemoveCell);
+export default (SamplesTable = connect(
+  ({ download: { dataSet } }) => ({
+    dataSet
+  }),
+  {
+    addExperiment,
+    removeSamplesFromExperiment
+  }
+)(SamplesTable));

--- a/src/containers/Experiment/SamplesTable.js
+++ b/src/containers/Experiment/SamplesTable.js
@@ -34,6 +34,11 @@ class SamplesTable extends React.Component {
     return this.props.accessionCodes.length;
   }
 
+  removeRow = rowId => {
+    const arrayCopy = this.state.data.filter(row => row.id !== rowId);
+    this.setState({ data: arrayCopy });
+  };
+
   render() {
     const { pageActionComponent } = this.props;
     // `pageActionComponent` is a render prop to add a component at the top right of the table
@@ -172,7 +177,7 @@ class SamplesTable extends React.Component {
         Header: 'Add/Remove',
         id: 'add_remove',
         Cell: AddRemoveCell.bind(this),
-        minWidth: 155,
+        minWidth: 200,
         className: 'samples-table__add-remove'
       },
       {
@@ -629,9 +634,15 @@ function TxtimportProtocol() {
   );
 }
 
-function AddRemoveCell({ original: sample }) {
+function AddRemoveCell({ original: sample, row: { id: rowId } }) {
   const { experimentAccessionCode, accession_code } = sample;
-  const { addExperiment, removeSamplesFromExperiment, dataSet } = this.props;
+  const { removeRow } = this;
+  const {
+    addExperiment,
+    removeSamplesFromExperiment,
+    dataSet,
+    isRowRemovable = false
+  } = this.props;
   const isAdded =
     dataSet[experimentAccessionCode] &&
     dataSet[experimentAccessionCode].includes(accession_code);
@@ -656,9 +667,10 @@ function AddRemoveCell({ original: sample }) {
 
   return (
     <RemoveFromDatasetButton
-      handleRemove={() =>
-        removeSamplesFromExperiment(experimentAccessionCode, [accession_code])
-      }
+      handleRemove={() => {
+        if (isRowRemovable) removeRow(rowId);
+        removeSamplesFromExperiment(experimentAccessionCode, [accession_code]);
+      }}
     />
   );
 }

--- a/src/containers/Experiment/SamplesTable.js
+++ b/src/containers/Experiment/SamplesTable.js
@@ -660,7 +660,7 @@ function AddRemoveCell({ original: sample, row: { id: rowId } }) {
           ])
         }
       >
-        Add to Dataset
+        Add
       </Button>
     );
   }

--- a/src/containers/Experiment/SamplesTable.js
+++ b/src/containers/Experiment/SamplesTable.js
@@ -86,7 +86,7 @@ class SamplesTable extends React.Component {
   }
 
   fetchData = async (tableState = false) => {
-    const { accessionCodes, experimentAccessionCode = '' } = this.props;
+    const { accessionCodes, experimentAccessionCodes = [] } = this.props;
     const { page, pageSize } = this.state;
     // get the backend ready `order_by` param, based on the sort options from the table
     let orderBy = this._getSortParam(tableState);
@@ -95,16 +95,25 @@ class SamplesTable extends React.Component {
 
     let offset = page * pageSize;
 
-    const sampleData = await getAllDetailedSamples({
+    let data = await getAllDetailedSamples({
       accessionCodes,
       orderBy,
       offset,
       limit: pageSize
     });
 
-    const data = sampleData.map(sample => {
-      return { ...sample, experimentAccessionCode };
-    });
+    if (experimentAccessionCodes.length === 1) {
+      const experimentAccessionCode = experimentAccessionCodes[0];
+
+      data = data.map(sample => {
+        return { ...sample, experimentAccessionCode };
+      });
+    } else if (experimentAccessionCodes.length > 1) {
+      data = data.map((sample, i) => {
+        const experimentAccessionCode = experimentAccessionCodes[i];
+        return { ...sample, experimentAccessionCode };
+      });
+    }
 
     // Customize the columns and their order depending on de data
     let columns = this._getColumns(data);
@@ -112,7 +121,6 @@ class SamplesTable extends React.Component {
     this.setState({
       data,
       columns,
-      experimentAccessionCode,
       pages: Math.ceil(this.totalSamples / pageSize),
       loading: false
     });

--- a/src/containers/Experiment/SamplesTable.js
+++ b/src/containers/Experiment/SamplesTable.js
@@ -178,7 +178,8 @@ class SamplesTable extends React.Component {
         id: 'add_remove',
         Cell: AddRemoveCell.bind(this),
         width: 190,
-        className: 'samples-table__add-remove'
+        className: 'samples-table__add-remove',
+        show: !!this.props.experimentAccessionCodes.length
       },
       {
         id: 'id',

--- a/src/containers/Experiment/SamplesTable.scss
+++ b/src/containers/Experiment/SamplesTable.scss
@@ -72,6 +72,12 @@
   .rt-tr.-even {
     background: $table-row--highlight;
   }
+
+  &__add-remove {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
 }
 
 

--- a/src/containers/Experiment/SamplesTable.scss
+++ b/src/containers/Experiment/SamplesTable.scss
@@ -78,6 +78,10 @@
     justify-content: center;
     align-items: center;
   }
+
+  .dataset-remove-button__added-container {
+    flex-direction: column;
+  }
 }
 
 

--- a/src/containers/Experiment/SamplesTable.scss
+++ b/src/containers/Experiment/SamplesTable.scss
@@ -75,12 +75,11 @@
 
   &__add-remove {
     display: flex;
-    justify-content: center;
     align-items: center;
   }
 
   .dataset-remove-button__added-container {
-    flex-direction: column;
+    display: block;
   }
 }
 

--- a/src/containers/Experiment/index.js
+++ b/src/containers/Experiment/index.js
@@ -158,7 +158,7 @@ let Experiment = ({
                       accessionCodes={experiment.samples.map(
                         x => x.accession_code
                       )}
-                      experimentAccessionCode={experiment.accession_code}
+                      experimentAccessionCodes={[experiment.accession_code]}
                       // Render prop for the button that adds the samples to the dataset
                       pageActionComponent={samplesDisplayed => (
                         <SampleTableActions samples={samplesDisplayed} />

--- a/src/containers/Experiment/index.js
+++ b/src/containers/Experiment/index.js
@@ -158,6 +158,7 @@ let Experiment = ({
                       accessionCodes={experiment.samples.map(
                         x => x.accession_code
                       )}
+                      experimentAccessionCode={experiment.accession_code}
                       // Render prop for the button that adds the samples to the dataset
                       pageActionComponent={samplesDisplayed => (
                         <SampleTableActions samples={samplesDisplayed} />

--- a/src/state/download/reducer.js
+++ b/src/state/download/reducer.js
@@ -76,14 +76,18 @@ export default (state = initialState, action) => {
 };
 
 export function groupSamplesBySpecies({ samples, dataSet }) {
-  return Object.keys(dataSet).reduce((species, id) => {
+  return Object.keys(dataSet).reduce((species, experimentAccessionCode) => {
     if (!Object.keys(samples).length) return species;
-    const experiment = samples[id];
+    const experiment = dataSet[experimentAccessionCode];
     if (!experiment || !experiment.length) return species;
-    experiment.forEach(sample => {
+    experiment.forEach(addedSample => {
+      const sample = samples[experimentAccessionCode].find(
+        sample => sample.accession_code === addedSample
+      );
       const { organism: { name: organismName } } = sample;
+      const modifiedSample = { ...sample, experimentAccessionCode };
       species[organismName] = species[organismName] || [];
-      species[organismName].push(sample);
+      species[organismName].push(modifiedSample);
     });
     return species;
   }, {});

--- a/src/state/download/reducer.js
+++ b/src/state/download/reducer.js
@@ -77,7 +77,8 @@ export default (state = initialState, action) => {
 
 export function groupSamplesBySpecies({ samples, dataSet }) {
   return Object.keys(dataSet).reduce((species, experimentAccessionCode) => {
-    if (!Object.keys(samples).length) return species;
+    if (!Object.keys(samples).length || !samples[experimentAccessionCode])
+      return species;
     const experiment = dataSet[experimentAccessionCode];
     if (!experiment || !experiment.length) return species;
     experiment.forEach(addedSample => {


### PR DESCRIPTION
## Issue Number
Closes #123 

## Purpose/Implementation Notes
* Add buttons to add/remove individual samples on samples table

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

* [x] New feature (non-breaking change which adds functionality)

## Functional tests
* Clicking "Add" button in row of samples table adds that sample to dataset
* Added samples show "Added to Dataset" indicator and "Remove" button
* Clicking on "Remove" on an already added sample will remove the sample from the dataset and show the "Add" button
* Removing samples on the downloads page samples tables will remove that row from the table as well

## Screenshots
![issue-123](https://user-images.githubusercontent.com/4724065/42647078-de3c1508-85d0-11e8-9e4f-a50b2a082aac.gif)

