### PR TITLE
Fixes the add to dataset button on the experiments page.

### DIFF
--- a/src/state/download/actions.js
+++ b/src/state/download/actions.js
@@ -136,7 +136,13 @@ export const addExperiment = experiments => {
     const prevDataSet = getState().download.dataSet;
     const newExperiments = experiments.reduce((result, experiment) => {
       if (experiment.samples.length) {
-        const sampleAccessions = experiment.samples;
+        var sampleAccessions = experiment.samples;
+        // If the samples property is a list of strings we're good.
+        // But if it's instead sample objects, we want to convert it
+        // to only being accession codes.
+        if (typeof sampleAccessions[0] != 'string') {
+          sampleAccessions = sampleAccessions.map(x => x.accession_code);
+        }
         result[experiment.accession_code] = prevDataSet[
           experiment.accession_code
         ]


### PR DESCRIPTION
## Issue Number

Related: https://github.com/AlexsLemonade/refinebio-frontend/issues/155

## Purpose/Implementation Notes

The add to dataset button works in a lot of places, but on the experiment view page itself. This fixes that.

The reason this was broken was because list of samples being posted to the dataset was a list of objects instead of just sample accession codes. This just checks for that case and corrects it.

## Types of changes

* [x] Bugfix (non-breaking change which fixes an issue)

## Functional tests

I've tested this in my local server and it worked!

## Checklist

* [x] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [x] I have added necessary documentation (if appropriate)
* [x] Any dependent changes have been merged and published in downstream modules
