### PR TITLE
Fix organism name crash

### DIFF
--- a/src/containers/Experiment/index.js
+++ b/src/containers/Experiment/index.js
@@ -98,7 +98,7 @@ let Experiment = ({
                   />{' '}
                   {organisms.length
                     ? organisms
-                        .map(organism => formatSentenceCase(organism))
+                        .map(organism => formatSentenceCase(organism.name))
                         .join(',')
                     : 'No species.'}
                 </div>


### PR DESCRIPTION
## Purpose/Implementation Notes

The frontend still crashed after the backend was merged because the organisms exposed by the API were serialized Organism objects and not strings with the organism name. I had to change the map statement to fix this.

## Types of changes

* [x] Bugfix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

The changes worked locally

## Checklist

_Put an `x` in the boxes that apply._

* [ ] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
* [ ] Any dependent changes have been merged and published in downstream modules

