### PR TITLE
Fix Adding to Dataset

### DIFF
--- a/src/containers/Experiment/index.js
+++ b/src/containers/Experiment/index.js
@@ -68,7 +68,9 @@ let Experiment = ({
                   {experiment.title || 'No Title.'}
                 </h3>
                 <div>
-                  {!dataSet[experiment.accession_code] ? (
+                  {!dataSet[experiment.accession_code] ||
+                  dataSet[experiment.accession_code].length !==
+                    experiment.samples.length ? (
                     <Button
                       text="Add to Dataset"
                       onClick={() => addExperiment([experiment])}

--- a/src/containers/Results/Result/index.js
+++ b/src/containers/Results/Result/index.js
@@ -36,7 +36,9 @@ export function RemoveFromDatasetButton({
 }
 
 const Result = ({ result, addExperiment, removeExperiment, dataSet }) => {
-  const isAdded = !!dataSet[result.accession_code];
+  const isAdded =
+    dataSet[result.accession_code] &&
+    dataSet[result.accession_code].length === result.samples.length;
 
   function handleAddExperiment() {
     addExperiment([result]);

--- a/src/state/download/actions.js
+++ b/src/state/download/actions.js
@@ -90,7 +90,9 @@ export const removeSpecies = samples => {
       }
     });
 
-    const { download: { dataSet, dataSetId } } = getState();
+    const {
+      download: { dataSet, dataSetId }
+    } = getState();
 
     const newDataSet = Object.keys(dataSet).reduce((result, accessionCode) => {
       const samples = dataSet[accessionCode];
@@ -146,7 +148,14 @@ export const addExperiment = experiments => {
         result[experiment.accession_code] = prevDataSet[
           experiment.accession_code
         ]
-          ? [...prevDataSet[experiment.accession_code], ...sampleAccessions]
+          ? // Remove duplicates from the array, since the backend throws errors
+            // on non-unique accessions
+            [
+              ...new Set([
+                ...prevDataSet[experiment.accession_code],
+                ...sampleAccessions
+              ])
+            ]
           : sampleAccessions;
       }
       return result;


### PR DESCRIPTION
## Issue Number

#119, #138, #148 

## Purpose/Implementation Notes

This fixes adding groups (pages or experiments) of samples to a dataset that already contains individual samples from that group.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

* [x] Bugfix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

I ran the frontend locally to verify the changes

## Checklist

_Put an `x` in the boxes that apply._

* [x] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
* [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

![2018-07-18-15 22 47-screenshot](https://user-images.githubusercontent.com/13942258/42903278-56abe43c-8a9f-11e8-9265-bfae520083b8.png)

