### PR TITLE
Fix #154

### DIFF
--- a/src/containers/DataSet/index.js
+++ b/src/containers/DataSet/index.js
@@ -48,7 +48,11 @@ class DataSet extends React.Component {
               {dataSetId &&
                 (this.props.dataSet.is_processed ||
                   !!this.props.dataSet.email_address) && (
-                  <ViewDownload dataSetId={dataSetId} isEmbed={true} />
+                  <ViewDownload
+                    dataSetId={dataSetId}
+                    isEmbed={true}
+                    isImmutable={true}
+                  />
                 )}
             </div>
           )
@@ -57,10 +61,13 @@ class DataSet extends React.Component {
     );
   }
 }
-DataSet = connect(({ dataSet }) => ({ dataSet }), {
-  fetchDataSet,
-  startDownload
-})(DataSet);
+DataSet = connect(
+  ({ dataSet }) => ({ dataSet }),
+  {
+    fetchDataSet,
+    startDownload
+  }
+)(DataSet);
 export default DataSet;
 
 /**

--- a/src/containers/Downloads/DownloadDetails.js
+++ b/src/containers/Downloads/DownloadDetails.js
@@ -21,7 +21,8 @@ export default function DownloadDetails({
   samplesBySpecies,
   experimentCountBySpecies,
   totalSamples,
-  totalExperiments
+  totalExperiments,
+  isImmutable = false
 }) {
   return (
     <div>
@@ -41,6 +42,7 @@ export default function DownloadDetails({
             <SpeciesSamples
               samplesBySpecies={samplesBySpecies}
               removeSpecies={removeSpecies}
+              isImmutable={isImmutable}
             />
           </div>
           <div className="downloads__card">
@@ -56,7 +58,11 @@ export default function DownloadDetails({
   );
 }
 
-const SpeciesSamples = ({ samplesBySpecies, removeSpecies }) => {
+const SpeciesSamples = ({
+  samplesBySpecies,
+  removeSpecies,
+  isImmutable = false
+}) => {
   const species = samplesBySpecies;
   if (!species || !Object.keys(species).length) {
     return <p>No samples added to download dataset.</p>;
@@ -92,6 +98,7 @@ const SpeciesSamples = ({ samplesBySpecies, removeSpecies }) => {
               experimentAccessionCodes={species[speciesName].map(
                 x => x.experimentAccessionCode
               )}
+              isImmutable={isImmutable}
             />
           )}
         </ModalManager>


### PR DESCRIPTION
## Issue Number

#154 

## Purpose/Implementation Notes

In all places in our app, we use the SamplesTable object to display lists of Samples, including on the downloading DataSet page. I introduced an isImmutable prop to SamplesTable, so in places where you would expect the dataset to be immutable it hides the 'Add/Remove' column.

## Types of changes

* [x] Bugfix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

I ran the frontend locally.

## Checklist

_Put an `x` in the boxes that apply._

* [x] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
* [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

![2018-07-19-10 24 12-screenshot](https://user-images.githubusercontent.com/13942258/42948877-702bbe88-8b3e-11e8-8c37-9402a13dcdee.png)

