### PR TITLE
Redirect to dataset page if job was sent

### DIFF
--- a/src/containers/Downloads/index.js
+++ b/src/containers/Downloads/index.js
@@ -90,9 +90,10 @@ Download = connect(
       areDetailsFetched,
       samples,
       dataSet,
-      experiments
-    },
-    dataSet: { is_processing, is_processed }
+      experiments,
+      is_processing,
+      is_processed
+    }
   }) => ({
     dataSetId,
     isLoading,

--- a/src/containers/Downloads/index.js
+++ b/src/containers/Downloads/index.js
@@ -1,5 +1,6 @@
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
+import { Redirect } from 'react-router-dom';
 
 import {
   removeExperiment,
@@ -41,7 +42,17 @@ class Download extends Component {
   }
 
   render() {
-    const { dataSetId, isLoading, areDetailsFetched, dataSet } = this.props;
+    const {
+      dataSetId,
+      isLoading,
+      areDetailsFetched,
+      dataSet,
+      is_processing
+    } = this.props;
+
+    if (is_processing) {
+      return <Redirect to={`/dataset/${dataSetId}`} />;
+    }
 
     return (
       <div className="downloads">
@@ -79,7 +90,8 @@ Download = connect(
       samples,
       dataSet,
       experiments
-    }
+    },
+    dataSet: { is_processing }
   }) => ({
     dataSetId,
     isLoading,
@@ -87,6 +99,7 @@ Download = connect(
     samples,
     dataSet,
     experiments,
+    is_processing,
     samplesBySpecies: groupSamplesBySpecies({
       samples: samples,
       dataSet: dataSet

--- a/src/containers/Downloads/index.js
+++ b/src/containers/Downloads/index.js
@@ -47,10 +47,11 @@ class Download extends Component {
       isLoading,
       areDetailsFetched,
       dataSet,
-      is_processing
+      is_processing,
+      is_processed
     } = this.props;
 
-    if (is_processing) {
+    if (is_processing || is_processed) {
       return <Redirect to={`/dataset/${dataSetId}`} />;
     }
 
@@ -91,7 +92,7 @@ Download = connect(
       dataSet,
       experiments
     },
-    dataSet: { is_processing }
+    dataSet: { is_processing, is_processed }
   }) => ({
     dataSetId,
     isLoading,
@@ -100,6 +101,7 @@ Download = connect(
     dataSet,
     experiments,
     is_processing,
+    is_processed,
     samplesBySpecies: groupSamplesBySpecies({
       samples: samples,
       dataSet: dataSet

--- a/src/state/download/actions.js
+++ b/src/state/download/actions.js
@@ -211,14 +211,20 @@ export const fetchDataSet = () => async dispatch => {
       dataSetId
     }
   });
-  const { data } = await getDataSet(dataSetId);
-  dispatch(fetchDataSetSucceeded(data));
+  const { data, is_processing, is_processed } = await getDataSet(dataSetId);
+  dispatch(fetchDataSetSucceeded(data, is_processing, is_processed));
 };
 
-export const fetchDataSetSucceeded = dataSet => ({
+export const fetchDataSetSucceeded = (
+  dataSet,
+  is_processing,
+  is_processed
+) => ({
   type: 'DOWNLOAD_DATASET_FETCH_SUCCESS',
   data: {
-    dataSet
+    dataSet,
+    is_processing,
+    is_processed
   }
 });
 

--- a/src/state/download/reducer.js
+++ b/src/state/download/reducer.js
@@ -18,10 +18,12 @@ export default (state = initialState, action) => {
       };
     }
     case 'DOWNLOAD_DATASET_FETCH_SUCCESS': {
-      const { dataSet } = action.data;
+      const { dataSet, is_processing, is_processed } = action.data;
       return {
         ...state,
         dataSet,
+        is_processing,
+        is_processed,
         isLoading: false
       };
     }
@@ -85,7 +87,9 @@ export function groupSamplesBySpecies({ samples, dataSet }) {
       const sample = samples[experimentAccessionCode].find(
         sample => sample.accession_code === addedSample
       );
-      const { organism: { name: organismName } } = sample;
+      const {
+        organism: { name: organismName }
+      } = sample;
       const modifiedSample = { ...sample, experimentAccessionCode };
       species[organismName] = species[organismName] || [];
       species[organismName].push(modifiedSample);


### PR DESCRIPTION
## Issue Number

Fixes #178 

## Purpose/Implementation Notes

Once we have began a smash job, it does not make sense to go back to the downloads page, since at the moment we have no concept of multiple local smash jobs. Because of that, this code redirects the user to view the status of the currently downloading dataset if the download button is pushed after a smash job was started.

## Types of changes

* [x] Bugfix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

I ran the frontend locally

## Checklist

_Put an `x` in the boxes that apply._

* [x] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
* [ ] Any dependent changes have been merged and published in downstream modules
