### PR TITLE
Fix #116

### DIFF
--- a/src/containers/Experiment/SamplesTable.js
+++ b/src/containers/Experiment/SamplesTable.js
@@ -45,6 +45,12 @@ class SamplesTable extends React.Component {
     // Good for a add/remove samples button. It's a function that receives the currently displayed
     // samples as an argument
     const totalPages = Math.ceil(this.totalSamples / this.state.pageSize);
+
+    // Calculate page size options to exclude ones greater than the number of
+    // samples.
+    const pageSizes = PAGE_SIZES.filter(size => size <= this.totalSamples);
+    if (pageSizes.length == 0) pageSizes.push(this.totalSamples);
+
     return (
       <ReactTable
         manual={true}
@@ -59,6 +65,7 @@ class SamplesTable extends React.Component {
         showPagination={false}
         columns={this.state.columns}
         ThComponent={ThComponent}
+        minRows={0}
       >
         {(state, makeTable, instance) => {
           return (
@@ -67,7 +74,7 @@ class SamplesTable extends React.Component {
                 <div className="experiment__per-page-dropdown">
                   Show
                   <Dropdown
-                    options={PAGE_SIZES}
+                    options={pageSizes}
                     selectedOption={this.state.pageSize}
                     onChange={this.handlePageSizeChange}
                   />


### PR DESCRIPTION
## Issue Number

#116

## Purpose/Implementation Notes

I added additional calculations to the page sizes options so that only the page sizes that are less than or equal to the number of samples will be displayed. For something with 9 or fewer samples, the only available option is the number of samples. I also added a prop to the ReactTable component to remove blank rows on the last page of a list of samples.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

* [x] Bugfix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

I ran the frontend locally.

## Checklist

_Put an `x` in the boxes that apply._

* [x] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
* [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots
Fewer than ten samples:
![2018-07-26-11 36 02-screenshot](https://user-images.githubusercontent.com/13942258/43273081-91bd2aec-90c9-11e8-9860-9a1318f8fb96.png)
Last page of a list of samples:
![2018-07-26-11 36 44-screenshot](https://user-images.githubusercontent.com/13942258/43273086-93adab4c-90c9-11e8-8165-92ddfb9ecfb1.png)

