### PR TITLE
Add CTA to all add buttons

### DIFF
--- a/src/containers/Experiment/SamplesTable.js
+++ b/src/containers/Experiment/SamplesTable.js
@@ -683,6 +683,7 @@ function AddRemoveCell({ original: sample, row: { id: rowId } }) {
             }
           ])
         }
+        buttonStyle={'secondary'}
       />
     );
   }

--- a/src/containers/Experiment/SamplesTable.js
+++ b/src/containers/Experiment/SamplesTable.js
@@ -12,7 +12,10 @@ import FileIcon from './file.svg';
 import ProcessIcon from './process.svg';
 import { PAGE_SIZES } from '../../constants/table';
 import SampleFieldMetadata from './SampleFieldMetadata';
-import { RemoveFromDatasetButton } from '../../containers/Results/Result';
+import {
+  RemoveFromDatasetButton,
+  AddToDatasetButton
+} from '../../containers/Results/Result';
 import {
   addExperiment,
   removeExperiment,
@@ -663,9 +666,9 @@ function AddRemoveCell({ original: sample, row: { id: rowId } }) {
     dataSet[experimentAccessionCode].includes(accession_code);
   if (!isAdded) {
     return (
-      <Button
-        buttonStyle="secondary"
-        onClick={() =>
+      <AddToDatasetButton
+        addMessage={'Add'}
+        handleAdd={() =>
           addExperiment([
             {
               accession_code: experimentAccessionCode,
@@ -673,9 +676,7 @@ function AddRemoveCell({ original: sample, row: { id: rowId } }) {
             }
           ])
         }
-      >
-        Add
-      </Button>
+      />
     );
   }
 

--- a/src/containers/Experiment/index.js
+++ b/src/containers/Experiment/index.js
@@ -234,7 +234,7 @@ let SampleTableActions = ({
           }
         ])
       }
-      samplesInDataset={samplesInDataset}
+      buttonStyle="secondary"
     />
   );
 SampleTableActions = connect(

--- a/src/containers/Experiment/index.js
+++ b/src/containers/Experiment/index.js
@@ -18,7 +18,7 @@ import {
   removeExperiment,
   removeSamplesFromExperiment
 } from '../../state/download/actions';
-import { RemoveFromDatasetButton } from '../Results/Result';
+import { RemoveFromDatasetButton, AddToDatasetButton } from '../Results/Result';
 
 import { goBack } from '../../state/routerActions';
 
@@ -71,9 +71,13 @@ let Experiment = ({
                   {!dataSet[experiment.accession_code] ||
                   dataSet[experiment.accession_code].length !==
                     experiment.samples.length ? (
-                    <Button
-                      text="Add to Dataset"
-                      onClick={() => addExperiment([experiment])}
+                    <AddToDatasetButton
+                      handleAdd={() => addExperiment([experiment])}
+                      samplesInDataset={
+                        dataSet[experiment.accession_code]
+                          ? dataSet[experiment.accession_code].length
+                          : null
+                      }
                     />
                   ) : (
                     <RemoveFromDatasetButton
@@ -203,7 +207,8 @@ let SampleTableActions = ({
   allSamplesInDataset,
   experiment,
   removeSamplesFromExperiment,
-  addExperiment
+  addExperiment,
+  samplesInDataset
 }) =>
   allSamplesInDataset ? (
     <RemoveFromDatasetButton
@@ -215,10 +220,9 @@ let SampleTableActions = ({
       }
     />
   ) : (
-    <Button
-      text="Add Page to Dataset"
-      buttonStyle="secondary"
-      onClick={() =>
+    <AddToDatasetButton
+      addMessage="Add Page to Dataset"
+      handleAdd={() =>
         addExperiment([
           {
             accession_code: experiment.accession_code,
@@ -226,6 +230,7 @@ let SampleTableActions = ({
           }
         ])
       }
+      samplesInDataset={samplesInDataset}
     />
   );
 SampleTableActions = connect(
@@ -234,7 +239,12 @@ SampleTableActions = connect(
     // should be true if all samples passed are already in the dataset
     allSamplesInDataset:
       samplesNotInDataSet(samples, experiment.accession_code, dataSet)
-        .length === 0
+        .length === 0,
+    samplesInDataset: samplesInDataset(
+      samples,
+      experiment.accession_code,
+      dataSet
+    ).length
   }),
   {
     addExperiment,
@@ -246,5 +256,12 @@ function samplesNotInDataSet(samples, accessionCode, dataSet) {
   return samples.filter(x => {
     if (!dataSet[accessionCode]) return true;
     return dataSet[accessionCode].indexOf(x.accession_code) === -1;
+  });
+}
+
+function samplesInDataset(samples, accessionCode, dataSet) {
+  return samples.filter(x => {
+    if (!dataSet[accessionCode]) return false;
+    return dataSet[accessionCode].indexOf(x.accession_code) !== -1;
   });
 }

--- a/src/containers/Results/Result/Result.scss
+++ b/src/containers/Results/Result/Result.scss
@@ -77,7 +77,8 @@
   }
 }
 
-.dataset-remove-button {
+.dataset-remove-button,
+.dataset-add-button {
   &__added {
     display: flex;
     align-items: center;

--- a/src/containers/Results/Result/index.js
+++ b/src/containers/Results/Result/index.js
@@ -44,6 +44,7 @@ export function AddToDatasetButton({
     <div className="dataset-add-button">
       <Button
         text={samplesInDataset ? 'Add Remaining' : addMessage}
+        buttonStyle={samplesInDataset ? 'secondary' : null}
         onClick={handleAdd}
       />
       {(samplesInDataset && (

--- a/src/containers/Results/Result/index.js
+++ b/src/containers/Results/Result/index.js
@@ -35,6 +35,28 @@ export function RemoveFromDatasetButton({
   );
 }
 
+export function AddToDatasetButton({
+  handleAdd,
+  samplesInDataset,
+  addMessage = 'Add to Dataset'
+}) {
+  return (
+    <div className="dataset-add-button">
+      <Button
+        text={samplesInDataset ? 'Add Remaining' : addMessage}
+        onClick={handleAdd}
+      />
+      {(samplesInDataset && (
+        <p className="dataset-add-button__info-text">
+          <i className="ion-information-circled dataset-add-button__info-icon" />{' '}
+          {samplesInDataset} Samples are already in Dataset
+        </p>
+      )) ||
+        null}
+    </div>
+  );
+}
+
 const Result = ({ result, addExperiment, removeExperiment, dataSet }) => {
   const isAdded =
     dataSet[result.accession_code] &&
@@ -68,7 +90,14 @@ const Result = ({ result, addExperiment, removeExperiment, dataSet }) => {
           </Link>
         </div>
         {!isAdded ? (
-          <Button text="Add to Dataset" onClick={handleAddExperiment} />
+          <AddToDatasetButton
+            handleAdd={handleAddExperiment}
+            samplesInDataset={
+              dataSet[result.accession_code]
+                ? dataSet[result.accession_code].length
+                : null
+            }
+          />
         ) : (
           <RemoveFromDatasetButton
             handleRemove={handleRemoveExperiment}

--- a/src/containers/Results/Result/index.js
+++ b/src/containers/Results/Result/index.js
@@ -38,13 +38,14 @@ export function RemoveFromDatasetButton({
 export function AddToDatasetButton({
   handleAdd,
   samplesInDataset,
-  addMessage = 'Add to Dataset'
+  addMessage = 'Add to Dataset',
+  buttonStyle = null
 }) {
   return (
     <div className="dataset-add-button">
       <Button
         text={samplesInDataset ? 'Add Remaining' : addMessage}
-        buttonStyle={samplesInDataset ? 'secondary' : null}
+        buttonStyle={samplesInDataset ? 'secondary' : buttonStyle}
         onClick={handleAdd}
       />
       {(samplesInDataset && (

--- a/src/containers/Results/Results.js
+++ b/src/containers/Results/Results.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import Result, { RemoveFromDatasetButton } from './Result';
+import Result, { RemoveFromDatasetButton, AddToDatasetButton } from './Result';
 import ResultFilters from './ResultFilters';
 import SearchInput from '../../components/SearchInput';
 import Pagination from '../../components/Pagination';
@@ -78,6 +78,14 @@ class Results extends Component {
       0
     );
 
+    const samplesAdded = results.reduce(
+      (sum, result) =>
+        dataSet[result.accession_code]
+          ? sum + dataSet[result.accession_code].length
+          : sum,
+      0
+    );
+
     return (
       <div className="results">
         <BackToTop />
@@ -102,19 +110,18 @@ class Results extends Component {
             <div className="results__list">
               <div className="results__top-bar">
                 {results.length ? <NumberOfResults /> : null}
-                {results.filter(result => !dataSet[result.accession_code])
-                  .length === 0 ? (
+                {totalSamplesOnPage - samplesAdded === 0 ? (
                   <RemoveFromDatasetButton
                     totalAdded={totalSamplesOnPage}
                     handleRemove={this.handlePageRemove}
                   />
                 ) : (
-                  <Button
-                    buttonStyle="secondary"
-                    text="Add Page to Dataset"
-                    onClick={() => {
+                  <AddToDatasetButton
+                    addMessage="Add Page to Dataset"
+                    handleAdd={() => {
                       addExperiment(results);
                     }}
+                    samplesInDataset={samplesAdded}
                   />
                 )}
               </div>
@@ -164,7 +171,11 @@ let NumberOfResults = ({
     </div>
   );
 NumberOfResults = connect(
-  ({ search: { pagination: { totalResults, resultsPerPage } } }) => ({
+  ({
+    search: {
+      pagination: { totalResults, resultsPerPage }
+    }
+  }) => ({
     totalResults,
     resultsPerPage
   }),

--- a/src/containers/Results/Results.js
+++ b/src/containers/Results/Results.js
@@ -126,6 +126,7 @@ class Results extends Component {
                       addExperiment(results);
                     }}
                     samplesInDataset={samplesAdded}
+                    buttonStyle="secondary"
                   />
                 )}
               </div>


### PR DESCRIPTION
## Issue Number

Fixes #197 and #130 

## Purpose/Implementation Notes

I added a CTA to all add buttons when a subset of the samples are already in the dataset. Also, I fixed the calculation on the results page for how many samples are in the dataset from that page.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

* [x] Bugfix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

I ran the frontend locally

## Checklist

_Put an `x` in the boxes that apply._

* [x] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
* [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

![2018-07-27-10 45 14-screenshot](https://user-images.githubusercontent.com/13942258/43328277-925fcb68-918b-11e8-81a1-b4e95dfdbe59.png)
![2018-07-27-10 45 24-screenshot](https://user-images.githubusercontent.com/13942258/43328283-95ee8670-918b-11e8-8cbc-ab21ad26c66b.png)

