### PR TITLE
Fix #206

### DIFF
--- a/src/containers/Downloads/index.js
+++ b/src/containers/Downloads/index.js
@@ -123,28 +123,37 @@ Download = connect(
       is_processed,
       aggregate_by
     }
-  }) => ({
-    dataSetId,
-    isLoading,
-    areDetailsFetched,
-    samples,
-    dataSet,
-    experiments,
-    is_processing,
-    is_processed,
-    aggregate_by,
-    samplesBySpecies: groupSamplesBySpecies({
-      samples: samples,
-      dataSet: dataSet
-    }),
-    filesData: downloadsFilesData(dataSet),
-    totalSamples: getTotalSamplesAdded({ dataSet }),
-    totalExperiments: getTotalExperimentsAdded({ dataSet }),
-    experimentCountBySpecies: getExperimentCountBySpecies({
+  }) => {
+    // If areDetailsFetched is false, either samples is already {} or the local dataset has more
+    // samples in it than the stored version of the remote one. The remote one will be refetched
+    // on load, but this makes sure that no errors happen due to an out of date local version.
+    if (!areDetailsFetched) {
+      samples = {};
+    }
+
+    return {
+      dataSetId,
+      isLoading,
+      areDetailsFetched,
+      samples,
+      dataSet,
       experiments,
-      dataSet
-    })
-  }),
+      is_processing,
+      is_processed,
+      aggregate_by,
+      samplesBySpecies: groupSamplesBySpecies({
+        samples: samples,
+        dataSet: dataSet
+      }),
+      filesData: downloadsFilesData(dataSet),
+      totalSamples: getTotalSamplesAdded({ dataSet }),
+      totalExperiments: getTotalExperimentsAdded({ dataSet }),
+      experimentCountBySpecies: getExperimentCountBySpecies({
+        experiments,
+        dataSet
+      })
+    };
+  },
   {
     removeSpecies,
     removeExperiment,

--- a/src/state/download/reducer.js
+++ b/src/state/download/reducer.js
@@ -45,6 +45,8 @@ export default (state = initialState, action) => {
         ...state,
         dataSetId,
         dataSet,
+        // When things are added the local details become desynced
+        areDetailsFetched: false,
         isLoading: false
       };
     }
@@ -102,7 +104,9 @@ export function groupSamplesBySpecies({ samples, dataSet }) {
       const sample = samples[experimentAccessionCode].find(
         sample => sample.accession_code === addedSample
       );
-      const { organism: { name: organismName } } = sample;
+      const {
+        organism: { name: organismName }
+      } = sample;
       const modifiedSample = { ...sample, experimentAccessionCode };
       species[organismName] = species[organismName] || [];
       species[organismName].push(modifiedSample);


### PR DESCRIPTION
## Issue Number

#206 

## Purpose/Implementation Notes

I traced the source of the crash in #206, and I found that when new samples were added to the dataset, they were stored in Redux in the array of accession codes, but that the old array of full sample objects remained. Then, when the downloads page was loaded, the old array of full objects and the new array of accession codes were used together in some calculations that raised exceptions when the two were out of sync. The fix is that the reducer marks the full sample objects as out of date with a pre-existing boolean when new samples are added to the dataset. Then in the mapStateToProps function we check that boolean and if the local copy is out of date it is treated as if it hasn't been fetched at all yet until it is fetched by the client-side code.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

* [x] Bugfix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

I ran the frontend locally.

## Checklist

_Put an `x` in the boxes that apply._

* [x] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
* [ ] Any dependent changes have been merged and published in downstream modules
