### PR TITLE
Clear current dataset if the server returns an error

### DIFF
--- a/src/common/helpers.js
+++ b/src/common/helpers.js
@@ -56,13 +56,22 @@ export async function asyncFetch(url, params = false) {
   const fullURL = process.env.REACT_APP_API_HOST
     ? `${process.env.REACT_APP_API_HOST}${url}`
     : url;
-  const response = await (!!params ? fetch(fullURL, params) : fetch(fullURL));
+
+  let response;
+  try {
+    response = await (!!params ? fetch(fullURL, params) : fetch(fullURL));
+  } catch (e) {
+    throw new Error(`Fatal error fetching ${url}`);
+  }
 
   /**
    * You only get an exception (rejection) when there's a network problem.
    * When the server answers, you have to check whether it's good or not.
    */
-  if (!response.ok) throw new Error(response.status);
+  if (!response.ok) {
+    debugger;
+    throw new Error(response.status);
+  }
   return await response.json();
 }
 

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,7 +1,8 @@
 const localStorageMock = {
   getItem: jest.fn(),
   setItem: jest.fn(),
-  clear: jest.fn()
+  clear: jest.fn(),
+  removeItem: jest.fn(),
 };
 // ref https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/template/README.md#srcsetuptestsjs-1
 global.localStorage = localStorageMock;

--- a/src/state/download/actions.js
+++ b/src/state/download/actions.js
@@ -4,6 +4,7 @@ import {
   getSamplesAndExperiments,
   updateDataSet
 } from '../../api/dataSet';
+import reportError from '../reportError';
 
 /**
  * Removes all experiments with the corresponding accession codes from dataset
@@ -211,22 +212,30 @@ export const fetchDataSet = () => async dispatch => {
       dataSetId
     }
   });
-  const {
-    data,
-    is_processing,
-    is_processed,
-    aggregate_by,
-    scale_by
-  } = await getDataSet(dataSetId);
-  dispatch(
-    fetchDataSetSucceeded(
+  try {
+    const {
       data,
       is_processing,
       is_processed,
       aggregate_by,
       scale_by
-    )
-  );
+    } = await getDataSet(dataSetId);
+
+    dispatch(
+      fetchDataSetSucceeded(
+        data,
+        is_processing,
+        is_processed,
+        aggregate_by,
+        scale_by
+      )
+    );
+  } catch (e) {
+    // Check if there was any error fetching the dataset, in which case restart it's status
+    await dispatch(clearDataSet());
+    // Also report the error
+    await dispatch(reportError(e));
+  }
 };
 
 export const fetchDataSetSucceeded = (

--- a/src/state/download/actions.test.js
+++ b/src/state/download/actions.test.js
@@ -1,0 +1,46 @@
+
+import {fetchDataSet} from './actions';
+import configureMockStore from 'redux-mock-store'
+import thunk from 'redux-thunk'
+import { REPORT_ERROR } from '../reportError';
+
+const middlewares = [thunk];
+const mockStore = configureMockStore(middlewares);
+
+describe('fetchDataSet', () => {
+  it('loads dataset in store', async () => {
+    const DataSetId = "08c429ab-01dd-43c7-b51a-c850ad4b9902";
+    const DataSet = {"id":DataSetId,"data":{}};
+
+    global.localStorage.getItem.mockReturnValueOnce(DataSetId);
+    global.fetch = jest
+      .fn()
+      .mockImplementation(() => Promise.resolve({ ok: true, json: () => Promise.resolve(DataSet) }));
+
+    const store = mockStore({ });
+
+    await store.dispatch(fetchDataSet());
+
+    expect(global.fetch.mock.calls[0]).toEqual([`/dataset/${DataSetId}/`]);
+    expect(global.localStorage.getItem.mock.calls[0]).toEqual(['dataSetId']);
+    expect(store.getActions().map((x)=> x.type)).toEqual(["DOWNLOAD_DATASET_FETCH", "DOWNLOAD_DATASET_FETCH_SUCCESS"]);
+  });
+
+  it('current dataset is removed with a fetch error', async () => {
+    const DataSetId = "08c429ab-01dd-43c7-b51a-c850ad4b9902";
+    const DataSet = {"id":DataSetId,"data":{}};
+
+    global.localStorage.getItem.mockReturnValueOnce(DataSetId);
+    global.fetch = jest
+      .fn()
+      .mockImplementation(() => {throw new Error('')});
+
+    const store = mockStore({ });
+
+    await store.dispatch(fetchDataSet());
+
+    expect(store.getActions().map((x)=> x.type)).toEqual(["DOWNLOAD_DATASET_FETCH", "DOWNLOAD_CLEAR", "DOWNLOAD_CLEAR_SUCCESS", REPORT_ERROR]);
+  });
+});
+
+

--- a/src/state/download/reducer.js
+++ b/src/state/download/reducer.js
@@ -86,6 +86,7 @@ export default (state = initialState, action) => {
       const { dataSet } = action.data;
       return {
         ...state,
+        dataSetId: null,
         dataSet,
         isLoading: false
       };


### PR DESCRIPTION
## Issue Number

Close #232 

## Purpose/Implementation Notes

>If we get a 404 error back from the Dataset endpoint, the application crashes irrecoverably. Worse, the crash persists because there's no way to get to the new dataset button. 

When there's an error fetching the dataset information, the current dataset is removed and a new one is started. The error is reported to Sentry.

## Types of changes

* [x] Bugfix (non-breaking change which fixes an issue)

## Functional tests

- Set an id on `localStorage`, for a dataset that didn't existed in the server. The app handles the error when the server doesn't return anything.

## Checklist

* [x] Lint and unit tests pass locally with my changes
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] I have added necessary documentation (if appropriate)
* [x] Any dependent changes have been merged and published in downstream modules
