### PR TITLE
Avoid fetching results if they are already in the store.

### DIFF
--- a/src/containers/Results/index.js
+++ b/src/containers/Results/index.js
@@ -22,10 +22,17 @@ import {
 } from '../Experiment/DataSetSampleActions';
 
 class Results extends Component {
-  state = { isLoading: true, query: '', filters: {} };
+  constructor(props) {
+    super(props);
+    this.state = {
+      isLoading: !props.results,
+      query: '',
+      filters: {}
+    };
+  }
 
   componentDidMount() {
-    this.updateResults();
+    this.updateResults(true);
   }
 
   async componentDidUpdate(prevProps) {
@@ -42,7 +49,7 @@ class Results extends Component {
   /**
    * Reads the search query and other parameters from the url and submits a new request to update the results.
    */
-  async updateResults() {
+  async updateResults(checkPreviousResults = false) {
     const { location } = this.props;
     let { q: query, p: page, size, ...filters } = getQueryParamObject(
       location.search
@@ -62,7 +69,20 @@ class Results extends Component {
     page = parseInt(page || 1, 10);
     size = parseInt(size || 10, 10);
 
-    this.setState({ query, filters, isLoading: true });
+    this.setState({ query, filters });
+
+    // Check if we already have these results fetched, in which case we don't need to make an additional request
+    // this can only happen when the component is initially mounted.
+    if (
+      checkPreviousResults &&
+      this.props.results &&
+      this.props.results.length > 0 &&
+      query === this.props.searchTerm
+    ) {
+      return;
+    }
+
+    this.setState({ isLoading: true });
     await this.props.fetchResults({ query, page, size, filters });
     this.setState({ isLoading: false });
   }


### PR DESCRIPTION
## Issue Number

close #126 

## Purpose/Implementation Notes

Modern browsers already maintain the position of the scrollbar automatically. This PR makes sure that the search results is rendered instantly when the user clicks on the back button. Before we were doing a request to the server.

## Types of changes

* Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

Search page, click on experiments.

## Checklist

_Put an `x` in the boxes that apply._

* [x] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
* [x] Any dependent changes have been merged and published in downstream modules

## Screenshots

![2018-08-27 14 04 45](https://user-images.githubusercontent.com/1882507/44676788-493a1580-aa02-11e8-92bf-8516faafe543.gif)

