### PR TITLE
Modal dialog with Samples Table fits on screen

### DIFF
--- a/src/components/Modal/Modal.scss
+++ b/src/components/Modal/Modal.scss
@@ -26,8 +26,14 @@
 
   // refers to modal dialogs that aren't centered and have a fixed distance from the top of the screen
   &--top {
-    padding-top: 80px;
-    padding-bottom: 160px;
+    @include tablet() {
+      padding: 24px 24px 40px 24px;
+    }
+
+    @include desktop() {
+      padding-top: 80px;
+      padding-bottom: 160px;
+    }
   }
 }
 
@@ -43,6 +49,12 @@
   background-color: $white;
   box-shadow: 0 2px 20px 0 rgba(0, 0, 0, 0.06);
   overflow: auto;
+  display: flex;
+
+  &__content {
+    flex: 1 1;
+    max-width: 100%;
+  }
 
   &__close {
     position: absolute;

--- a/src/components/Modal/Modal.scss
+++ b/src/components/Modal/Modal.scss
@@ -1,54 +1,58 @@
 @import '../../common/styles/variables';
 
 // This class is applied to the body element when a modal dialog is displayed to disable scrolling
-/*body*/.modal-open {
-    overflow: hidden;
-    position: relative;
+/*body*/
+.modal-open {
+  overflow: hidden;
+  position: relative;
 }
 
 .modal-backdrop {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    z-index: 1000;
-    overflow: auto;
-    background-color: rgba(0,0,0,0.5);
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 1000;
+  overflow: auto;
+  background-color: rgba(0, 0, 0, 0.5);
 
-    // center vertically the modal dialog
-    &--center {
-        display: flex;
-        flex-direction: column;
-        justify-content: center;
-    }
+  // center vertically the modal dialog
+  &--center {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  }
 
-    // refers to modal dialogs that aren't centered and have a fixed distance from the top of the screen
-    &--top {
-        padding-top: 80px;
-        padding-bottom: 160px;
-    }
-
+  // refers to modal dialogs that aren't centered and have a fixed distance from the top of the screen
+  &--top {
+    padding-top: 80px;
+    padding-bottom: 160px;
+  }
 }
 
 .modal {
-    position: relative;
-    width: auto;
-    max-width: 500px;
-    width: 100%;
-    margin-left: auto;
-    margin-right: auto;
-    padding: 16px;
-    border: 1px solid $border-color;	
-    background-color: $white;	
-    box-shadow: 0 2px 20px 0 rgba(0,0,0,0.06);
-    overflow: auto;
+  position: relative;
+  width: auto;
+  max-width: 500px;
+  width: 100%;
+  margin-left: auto;
+  margin-right: auto;
+  padding: 16px;
+  border: 1px solid $border-color;
+  background-color: $white;
+  box-shadow: 0 2px 20px 0 rgba(0, 0, 0, 0.06);
+  overflow: auto;
 
-    &__close {
-        position: absolute;
-        top: 16px;
-        right: 16px;
-        line-height: 1;
-    }
+  &__close {
+    position: absolute;
+    top: 16px;
+    right: 16px;
+    line-height: 1;
+  }
+
+  &--fill-page {
+    max-height: 100%;
+    overflow: hidden;
+  }
 }
-

--- a/src/components/Modal/ModalManager.js
+++ b/src/components/Modal/ModalManager.js
@@ -54,17 +54,19 @@ export default class ModalManager extends React.Component {
           }`}
           bodyOpenClassName="modal-open"
         >
-          {this.props.children({
-            hideModal: this.hideModal
-          })}
+          <div className="modal__content">
+            {this.props.children({
+              hideModal: this.hideModal
+            })}
 
-          <Button
-            className="modal__close"
-            onClick={this.hideModal}
-            buttonStyle="transparent"
-          >
-            <i className="icon ion-close" />
-          </Button>
+            <Button
+              className="modal__close"
+              onClick={this.hideModal}
+              buttonStyle="transparent"
+            >
+              <i className="icon ion-close" />
+            </Button>
+          </div>
         </Modal>
       </React.Fragment>
     );

--- a/src/components/Modal/ModalManager.js
+++ b/src/components/Modal/ModalManager.js
@@ -18,7 +18,14 @@ if (process.env.NODE_ENV !== 'test') Modal.setAppElement('#root');
 //   </ModalManager>
 export default class ModalManager extends React.Component {
   static defaultProps = {
-    modalProps: {}
+    // set custom properties to the modal
+    modalProps: {
+      // center the modal vertically in the page
+      center: false,
+
+      // Prevents the modal from being bigger than the screen when true
+      fillPage: false
+    }
   };
 
   state = {
@@ -42,7 +49,9 @@ export default class ModalManager extends React.Component {
               ? 'modal-backdrop--center'
               : 'modal-backdrop--top'
           }`}
-          className={`modal ${this.props.modalProps.className || ''}`}
+          className={`modal ${this.props.modalProps.className || ''}  ${
+            this.props.modalProps.fillPage ? 'modal--fill-page' : ''
+          }`}
           bodyOpenClassName="modal-open"
         >
           {this.props.children({

--- a/src/containers/Downloads/DownloadDetails.js
+++ b/src/containers/Downloads/DownloadDetails.js
@@ -329,7 +329,7 @@ class ViewSamplesButtonModal extends React.Component {
             }}
           />
         )}
-        modalProps={{ className: 'samples-modal' }}
+        modalProps={{ className: 'samples-modal', fillPage: true }}
       >
         {() => (
           <SamplesTable

--- a/src/containers/Experiment/Experiment.scss
+++ b/src/containers/Experiment/Experiment.scss
@@ -109,11 +109,6 @@
     margin-bottom: 8px;
   }
 
-  &__table-container {
-    position: relative;
-    margin-bottom: 16px;
-  }
-
   &__not-provided {
     color: $dusty-gray;
     font-style: italic;

--- a/src/containers/Experiment/SamplesTable.js
+++ b/src/containers/Experiment/SamplesTable.js
@@ -152,41 +152,49 @@ class SamplesTable extends React.Component {
       >
         {(state, makeTable, instance) => {
           return (
-            <div>
-              <div className="experiment__sample-commands">
-                <div className="experiment__per-page-dropdown">
-                  Show
-                  <Dropdown
-                    options={pageSizes}
-                    selectedOption={this.state.pageSize}
-                    onChange={this.handlePageSizeChange}
-                  />
-                  of {this.totalSamples} Samples
-                </div>
-                {pageActionComponent &&
-                  pageActionComponent(state.pageRows.map(x => x._original))}
-              </div>
-              <div className="experiment__table-container">
-                <div className="samples-table__scroll-left">
-                  <div className="samples-table__scroll-button">{'<'}</div>
-                </div>
-                {makeTable()}
-                <div className="samples-table__scroll-right">
-                  <div className="samples-table__scroll-button">{'>'}</div>
+            <div className="samples-table-layout">
+              <div className="samples-table-layout__header">
+                <div className="experiment__sample-commands">
+                  <div className="experiment__per-page-dropdown">
+                    Show
+                    <Dropdown
+                      options={pageSizes}
+                      selectedOption={this.state.pageSize}
+                      onChange={this.handlePageSizeChange}
+                    />
+                    of {this.totalSamples} Samples
+                  </div>
+                  {pageActionComponent &&
+                    pageActionComponent(state.pageRows.map(x => x._original))}
                 </div>
               </div>
-              <div>
-                <img src={InfoIcon} className="info-icon" alt="" /> Some fileds
-                may be harmonized.{' '}
-                <Link to="/docs" className="link">
-                  Learn more
-                </Link>
+
+              <div className="samples-table-layout__main">
+                <div className="samples-table-container">
+                  <div className="samples-table__scroll-left">
+                    <div className="samples-table__scroll-button">{'<'}</div>
+                  </div>
+                  {makeTable()}
+                  <div className="samples-table__scroll-right">
+                    <div className="samples-table__scroll-button">{'>'}</div>
+                  </div>
+                </div>
               </div>
-              <Pagination
-                onPaginate={this.handlePagination}
-                totalPages={totalPages}
-                currentPage={this.state.page + 1}
-              />
+
+              <div className="samples-table-layout__footer">
+                <div>
+                  <img src={InfoIcon} className="info-icon" alt="" /> Some
+                  fileds may be harmonized.{' '}
+                  <Link to="/docs" className="link">
+                    Learn more
+                  </Link>
+                </div>
+                <Pagination
+                  onPaginate={this.handlePagination}
+                  totalPages={totalPages}
+                  currentPage={this.state.page + 1}
+                />
+              </div>
             </div>
           );
         }}

--- a/src/containers/Experiment/SamplesTable.scss
+++ b/src/containers/Experiment/SamplesTable.scss
@@ -1,6 +1,40 @@
 @import '../../common/styles/variables';
 @import '../../common/styles/mixins';
+
+.samples-table-layout {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+
+  &__header {
+  }
+
+  &__main {
+    flex: 1 1;
+    overflow: hidden;
+
+    // the horizontal scroll buttons overflow outside of the table
+    // this is to make sure they are displayed
+    padding-left: 16px;
+    margin-left: -16px;
+    padding-right: 16px;
+    margin-right: -16px;
+  }
+
+  &__footer {
+    padding-top: 16px;
+  }
+}
+
+.samples-table-container {
+  position: relative;
+  height: 100%;
+}
+
 .samples-table {
+  height: 100%;
+  max-height: 115 * 8px;
+
   &__th {
     // The original styles for headers in ReactTable are under the selector: .ReactTable .rt-thead .rt-th.-sort-asc
     // !important is here to override that one


### PR DESCRIPTION
## Issue Number

close #114 

## Purpose/Implementation Notes

Adds scrollbars in the modal dialog with the samples table.

The height of the samples table is also capped on the experiments page, when there are more than 10 samples.

/cc @dvenprasad 

## Types of changes

* [x] New feature (non-breaking change which adds functionality)
* [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

Test modal dialogs everywhere.

## Checklist

* [x] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
* [x] Any dependent changes have been merged and published in downstream modules

## Screenshots

![2018-08-30 16 47 49](https://user-images.githubusercontent.com/1882507/44878296-7b52ae00-ac74-11e8-9d78-002e4b9f07aa.gif)

![2018-08-30 16 48 37](https://user-images.githubusercontent.com/1882507/44878323-945b5f00-ac74-11e8-8f1b-bbd4b6af75cf.gif)



