### PR TITLE
Ensure we check the current filters before showing cached search results

### DIFF
--- a/src/containers/Main/index.js
+++ b/src/containers/Main/index.js
@@ -10,7 +10,7 @@ import DatasetIcon from '../../common/icons/dataset.svg';
 import './Main.scss';
 import StatsPlaceholder from './summary-stats-placeholder.svg';
 
-const Main = ({ searchTerm, fetchResults, push }) => {
+let Main = ({ searchTerm, fetchResults, push }) => {
   return (
     <div className="main">
       <Helmet>
@@ -29,11 +29,17 @@ const Main = ({ searchTerm, fetchResults, push }) => {
           <div className="main__search-suggestions">
             <p className="main__search-suggestion-label">Try searching for:</p>
 
-            {['Notch', 'Medulloblastoma', 'GSE16476', 'Versteeg'].map(q => (
-              <Link className="main__search-suggestion" to={`/results?q=${q}`}>
-                {q}
-              </Link>
-            ))}
+            {['Notch', 'Medulloblastoma', 'GSE16476', 'Versteeg'].map(
+              (q, index) => (
+                <Link
+                  className="main__search-suggestion"
+                  to={`/results?q=${q}`}
+                  key={index}
+                >
+                  {q}
+                </Link>
+              )
+            )}
           </div>
         </div>
       </section>
@@ -142,18 +148,9 @@ const Main = ({ searchTerm, fetchResults, push }) => {
   );
 };
 
-const mapStateToProps = state => {
-  const {
-    search: { searchTerm }
-  } = state;
-  return {
-    searchTerm
-  };
-};
-
-const MainContainer = connect(
-  mapStateToProps,
+Main = connect(
+  ({ search: { searchTerm } }) => ({ searchTerm }),
   { fetchResults, push }
 )(Main);
 
-export default MainContainer;
+export default Main;

--- a/src/containers/Results/index.js
+++ b/src/containers/Results/index.js
@@ -17,6 +17,7 @@ import StartSearchingImage from '../../common/images/start-searching.svg';
 import GhostSampleImage from '../../common/images/ghost-sample.svg';
 import { Link } from 'react-router-dom';
 import DataSetSampleActions from '../Experiment/DataSetSampleActions';
+import isEqual from 'lodash/isEqual';
 
 class Results extends Component {
   constructor(props) {
@@ -74,7 +75,8 @@ class Results extends Component {
       checkPreviousResults &&
       this.props.results &&
       this.props.results.length > 0 &&
-      query === this.props.searchTerm
+      query === this.props.searchTerm &&
+      isEqual(filters, this.props.appliedFilters)
     ) {
       return;
     }
@@ -178,14 +180,22 @@ class Results extends Component {
 }
 Results = connect(
   ({
-    search: { results, filters, pagination, searchTerm, isSearching },
+    search: {
+      results,
+      filters,
+      pagination,
+      searchTerm,
+      isSearching,
+      appliedFilters
+    },
     download: { dataSet }
   }) => ({
     results,
     pagination,
     searchTerm,
     dataSet,
-    isLoading: isSearching
+    isLoading: isSearching,
+    appliedFilters
   }),
   {
     ...resultsActions,


### PR DESCRIPTION
## Issue Number

close #294 

## Purpose/Implementation Notes

Ensure we check the current filters before showing cached search results

## Types of changes

* [x] Bugfix (non-breaking change which fixes an issue)

## Functional tests

Steps in #294:

- Search for "human"
- Apply some filter
- Visit the home page
- Search "human" from the search input

## Checklist

* [x] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
* [x] Any dependent changes have been merged and published in downstream modules

