### PR TITLE
Show correct platform badge based on search results `technologies` field

### DIFF
--- a/src/containers/Experiment/index.js
+++ b/src/containers/Experiment/index.js
@@ -113,10 +113,10 @@ let Experiment = ({
                 <div className="experiment__stats-item">
                   <TechnologyBadge
                     className="experiment__stats-icon"
-                    isMicroarray={experiment.samples.every(
+                    isMicroarray={experiment.samples.some(
                       x => x.technology === MICROARRAY
                     )}
-                    isRnaSeq={experiment.samples.every(
+                    isRnaSeq={experiment.samples.some(
                       x => x.technology === RNA_SEQ
                     )}
                   />

--- a/src/containers/Results/Result/index.js
+++ b/src/containers/Results/Result/index.js
@@ -6,7 +6,10 @@ import SampleIcon from '../../../common/icons/sample.svg';
 import './Result.scss';
 import { formatSentenceCase, getMetadataFields } from '../../../common/helpers';
 import DataSetSampleActions from '../../Experiment/DataSetSampleActions';
-import TechnologyBadge from '../../../components/TechnologyBadge';
+import TechnologyBadge, {
+  MICROARRAY,
+  RNA_SEQ
+} from '../../../components/TechnologyBadge';
 
 const Result = ({ result, addExperiment, removeExperiment }) => {
   const metadataFields = getMetadataFields(result);
@@ -64,10 +67,15 @@ const Result = ({ result, addExperiment, removeExperiment }) => {
             : null}
         </li>
         <li className="result__stat">
-          {/* Right now we don't have a way to determine the technology of an experiment, since
-          there's no sample information in the search endpoint. This should be updated after 
-          https://github.com/AlexsLemonade/refinebio-frontend/issues/268#issuecomment-416300232 */}
-          <TechnologyBadge className="result__icon" isMicroarray={true} />
+          <TechnologyBadge
+            className="result__icon"
+            isMicroarray={
+              result.technologies && result.technologies.contains(MICROARRAY)
+            }
+            isRnaSeq={
+              result.technologies && result.technologies.contains(RNA_SEQ)
+            }
+          />
           {result.pretty_platforms.filter(platform => !!platform).join(',')}
         </li>
       </ul>


### PR DESCRIPTION
## Issue Number

close #268 

## Purpose/Implementation Notes

With the new field `technologies` that was added in https://github.com/AlexsLemonade/refinebio/pull/589 we can calculate the right platform badge for search results.

## Types of changes

* [x] New feature (non-breaking change which adds functionality)

## Functional tests

Check search page

## Checklist

* [x] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
* [x] Any dependent changes have been merged and published in downstream modules

## Screenshots

![image](https://user-images.githubusercontent.com/1882507/45315349-35160e00-b502-11e8-9340-18f6393a4c2c.png)

