### PR TITLE
Show all results for empty search query

### DIFF
--- a/src/containers/Main/index.js
+++ b/src/containers/Main/index.js
@@ -22,7 +22,9 @@ let Main = ({ searchTerm, fetchResults, push }) => {
             Search for harmonized transcriptome data
           </h1>
           <SearchInput
-            onSubmit={value => push(`/results?q=${value.search}`)}
+            onSubmit={value =>
+              push(value.search ? `/results?q=${value.search}` : `/results`)
+            }
             searchTerm={searchTerm}
             buttonStyle="primary"
           />

--- a/src/containers/Results/index.js
+++ b/src/containers/Results/index.js
@@ -13,7 +13,6 @@ import './Results.scss';
 import { updateResultsPerPage } from '../../state/search/actions';
 import Dropdown from '../../components/Dropdown';
 import { PAGE_SIZES } from '../../constants/table';
-import StartSearchingImage from '../../common/images/start-searching.svg';
 import GhostSampleImage from '../../common/images/ghost-sample.svg';
 import { Link } from 'react-router-dom';
 import DataSetSampleActions from '../Experiment/DataSetSampleActions';
@@ -96,9 +95,7 @@ class Results extends Component {
           fetch={() => this.updateResults()}
         >
           {({ isLoading }) =>
-            !searchTerm ? (
-              <NoSearchTerm />
-            ) : isLoading ? (
+            isLoading ? (
               <Spinner />
             ) : !results.length && !anyFilterApplied(this.state.filters) ? (
               <NoSearchResults />
@@ -184,14 +181,7 @@ class Results extends Component {
 }
 Results = connect(
   ({
-    search: {
-      results,
-      filters,
-      pagination,
-      searchTerm,
-      isSearching,
-      appliedFilters
-    },
+    search: { results, pagination, searchTerm, isSearching, appliedFilters },
     download: { dataSet }
   }) => ({
     results,
@@ -241,33 +231,6 @@ NumberOfResults = connect(
   }),
   { updateResultsPerPage }
 )(NumberOfResults);
-
-/**
- * Displayed when the user tries to search for an empty term
- */
-const NoSearchTerm = () => {
-  return (
-    <div className="results__no-results">
-      <h2>Try searching for</h2>
-      <div className="results__suggestions">
-        {['Notch', 'Medulloblastoma', 'GSE16476', 'Versteeg'].map(q => (
-          <Link
-            className="link results__suggestion"
-            to={`/results?q=${q}`}
-            key={q}
-          >
-            {q}
-          </Link>
-        ))}
-      </div>
-      <img
-        src={StartSearchingImage}
-        alt="Start searching"
-        className="results__no-results-image img-responsive"
-      />
-    </div>
-  );
-};
 
 const NoSearchResults = () => (
   <div className="results__no-results">

--- a/src/state/search/actions.js
+++ b/src/state/search/actions.js
@@ -23,22 +23,6 @@ const navigateToResults = ({ query, page, size, filters }) => {
 
 export function fetchResults({ query, page = 1, size = 10, filters }) {
   return async (dispatch, getState) => {
-    if (!query) {
-      dispatch({
-        type: 'SEARCH_RESULTS_FETCH',
-        data: {
-          searchTerm: '',
-          results: [],
-          filters,
-          totalResults: 0,
-          resultsPerPage: size,
-          currentPage: page,
-          appliedFilters: {}
-        }
-      });
-      return;
-    }
-
     try {
       const {
         results,


### PR DESCRIPTION
## Issue Number

close #316 

## Purpose/Implementation Notes

Show all results when the user enters an empty search query. From the landing page, clicking search will navigate to `/results`, *without the `?q` paramter.

## Functional tests

Search from landing page.

## Checklist

* [x] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
* [x] Any dependent changes have been merged and published in downstream modules

## Screenshots

![image](https://user-images.githubusercontent.com/1882507/46111522-4a9f5f00-c1b5-11e8-856b-64b3013dd2a8.png)


