### PR TITLE
Prevent deploys from non-tags by fixing circleci config.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,52 +8,24 @@ jobs:
       - run: yarn install --ignore-engines
       - run: yarn test
 
-  deploy-dev:
+  deploy:
     docker:
       - image: circleci/python:3-node
     steps:
       - checkout
-      - run: yarn install --ignore-engines
-
-      # TODO: Maybe fix this? Or at least delete this comment
-      - run: CI=false REACT_APP_API_HOST=https://api.staging.refine.bio yarn run build
-      - run: pip install awscli --upgrade --user
-
-      # I'm not sure why it installs here but it does...
-      - run: ~/.local/bin/aws s3 sync build s3://staging.refine.bio --delete --acl public-read
-
-  deploy-master:
-    docker:
-      - image: circleci/python:3-node
-    steps:
-      - checkout
-      - run: yarn install --ignore-engines
-
-      # TODO: Maybe fix this? Or at least delete this comment
-      - run: CI=false REACT_APP_API_HOST=https://api.refine.bio yarn run build
-      - run: pip install awscli --upgrade --user
-
-      # I'm not sure why it installs here but it does...
-      - run: ~/.local/bin/aws s3 sync build s3://refine.bio --delete --acl public-read
+      - run: bash .circleci/deploy.sh
 
 workflows:
   version: 2
   test-and-deploy:
     jobs:
       - test
-      - deploy-dev:
+      - deploy:
           requires:
             - test
           filters:
             branches:
-              only: dev
-            tags:
-              only: /v.*/
-      - deploy-master:
-          requires:
-            - test
-          filters:
-            branches:
-              only: master
+              # No branch commit will ever trigger this job.
+              ignore: /.*/
             tags:
               only: /v.*/

--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# A tag is linked to a commit hash, not a branch. A single commit hash
+# can end up on multiple branches. So we first check to see if we're
+# on master, then on dev, then error out because we should only deploy master or dev.
+get_master_or_dev() {
+    master_check=$(git log --decorate=full | head -1 | grep origin/master || true)
+    dev_check=$(git log --decorate=full | head -1 | grep origin/dev || true)
+
+    if [[ ! -z $master_check ]]; then
+        echo "master"
+    elif [[ ! -z $dev_check ]]; then
+        echo "dev"
+    else
+        echo "Why in the world was update_docker_img.sh called from a branch other than dev or master?!?!?"
+        exit 1
+    fi
+}
+
+branch=$(get_master_or_dev)
+
+if [[ $branch == "master" ]]; then
+    base_host="refine.bio"
+elif [[ $branch == "dev" ]]; then
+    base_host="staging.refine.bio"
+else
+    echo "Why in the world was update_docker_img.sh called from a branch other than dev or master?!?!?"
+    exit 1
+fi
+
+yarn install --ignore-engines
+
+CI=false REACT_APP_API_HOST=https://api.$base_host yarn run build
+
+pip install awscli --upgrade --user
+
+~/.local/bin/aws s3 sync build s3://$base_host --delete --acl public-read


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio-frontend/pull/85
https://github.com/AlexsLemonade/refinebio-frontend/pull/278
https://github.com/AlexsLemonade/refinebio-frontend/pull/332
Didn't quite do what they said they did.

## Purpose/Implementation Notes

Circleci's filters are confusing because `branch` and `tag` filter categories don't combine, it uses one or the other depending on whether a branch or a tag triggered the build. This makes it so the deploys won't happen on branches ever and that on tags it will determine the branch correctly.

## Types of changes

* [x] Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A can't test without running CI on these branches.
