### PR TITLE
Add filter to test to allow tags to trigger builds.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,12 @@ workflows:
   version: 2
   test-and-deploy:
     jobs:
-      - test
+      - test:
+          filters:
+            # To allow tag commits whose name start with "v" to trigger
+            # "test" job, an explicit "tags" filter is required here.
+            tags:
+              only: /v.*/
       - deploy:
           requires:
             - test


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio-frontend/pull/334 didn't quite work.

## Purpose/Implementation Notes

Based on https://discuss.circleci.com/t/builds-for-tags-not-triggering/17681/4 I think this might fix it, but I'm not sure and unfortunately a long series of PRs is the only way to iterate on this issue.

## Types of changes

* [x] Bugfix (non-breaking change which fixes an issue)
