### PR TITLE
Check experiment title/description before trying to set metadata

### DIFF
--- a/src/containers/Experiment/index.js
+++ b/src/containers/Experiment/index.js
@@ -265,11 +265,15 @@ export default Experiment;
 function ExperimentHelmet({ experiment }) {
   return (
     <Helmet>
-      <title>{truncateOnWord(experiment.title, 60, '')} - refine.bio</title>
-      <meta
-        name="description"
-        content={truncateOnWord(experiment.description, 160)}
-      />
+      {experiment.title && (
+        <title>{truncateOnWord(experiment.title, 60, '')} - refine.bio</title>
+      )}
+      {experiment.description && (
+        <meta
+          name="description"
+          content={truncateOnWord(experiment.description, 160)}
+        />
+      )}
     </Helmet>
   );
 }


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

I think this bug was introduced after merging https://github.com/AlexsLemonade/refinebio-frontend/pull/359 and https://github.com/AlexsLemonade/refinebio-frontend/pull/373 together.

This PR checks if the experiment has a title and description before trying to set the page metadata.
