### PR TITLE
Show error when the dataset processing fails

### DIFF
--- a/src/common/styles/_variables.scss
+++ b/src/common/styles/_variables.scss
@@ -28,6 +28,8 @@ $background-color--blue-gradient: linear-gradient(
   #4b6db1 100%
 );
 
+$color-error: #db3b28;
+
 $border-color: $gray;
 $border-color--light: #f2f2f2;
 

--- a/src/containers/Downloads/DataSet/DataSet.scss
+++ b/src/containers/Downloads/DataSet/DataSet.scss
@@ -1,4 +1,5 @@
 @import '../../../common/styles/variables.scss';
+@import url('https://fonts.googleapis.com/css?family=Oxygen+Mono');
 
 .dataset {
   &__message {
@@ -75,6 +76,19 @@
 
   &__way-subtitle {
     margin-bottom: 32px;
+  }
+
+  &__try-again-button {
+    margin-bottom: 16px;
+  }
+
+  &__failure-reason {
+    margin-top: 16px;
+    color: $color-error;
+    margin-bottom: 16px;
+    font-family: 'Oxygen Mono', monospace;
+    background-color: #f2f2f2;
+    padding: 8px;
   }
 }
 

--- a/src/containers/Downloads/DataSet/index.js
+++ b/src/containers/Downloads/DataSet/index.js
@@ -146,11 +146,15 @@ function DataSetPageHeader({ dataSetId, email_address, hasError, dataSet }) {
     is_available,
     expires_on,
     s3_bucket,
-    s3_key
+    s3_key,
+    success
   } = dataSet;
 
+  // success can sometimes be `null`
+  const processingError = success === false;
+
   const isExpired = moment(expires_on).isBefore(Date.now());
-  return hasError ? (
+  return hasError || processingError ? (
     <DataSetErrorDownloading dataSetId={dataSetId} dataSet={dataSet} />
   ) : is_processed ? (
     is_available && !isExpired ? (
@@ -178,15 +182,9 @@ let DataSetErrorDownloading = ({
           <div className="dataset__processed-text">
             <h1>Uh-oh something went wrong!</h1>
             <p>Please try downloading again. </p>
-            <p>
-              If the problem persists, please contact{' '}
-              <a href="mailto:ccdl@alexslemonade.org" className="link">
-                ccdl@alexslemonade.org
-              </a>
-            </p>
-
             {token && (
               <Button
+                className="dataset__try-again-button"
                 onClick={() =>
                   startDownload({
                     tokenId: token,
@@ -197,6 +195,34 @@ let DataSetErrorDownloading = ({
               >
                 Try Again
               </Button>
+            )}
+
+            <p>
+              If the problem persists, please contact{' '}
+              <a href="mailto:ccdl@alexslemonade.org" className="link">
+                ccdl@alexslemonade.org
+              </a>
+              {dataSet.failure_reason && (
+                <span>
+                  {' '}
+                  or{' '}
+                  <a
+                    href="https://github.com/AlexsLemonade/refinebio/issues/new"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="link"
+                  >
+                    file a ticket on Github
+                  </a>{' '}
+                  with the below error message:
+                </span>
+              )}
+            </p>
+
+            {dataSet.failure_reason && (
+              <div className="dataset__failure-reason">
+                {dataSet.failure_reason}
+              </div>
             )}
           </div>
 


### PR DESCRIPTION
## Issue Number

close #377 

## Purpose/Implementation Notes

This shows any error message returned from the backend when there's an error processing a dataset, and allows the users to re-try the process.

I wasn't able to get a dataset to fail locally, so I tested this setting the values manually in the front-end.

```
  dataSet.success = false;
  dataSet.failure_reason =
    'Failed Kolmogorov Smirnov test! Stat: 0.6254109910756225, PVal: 0.0';
```

This needs https://github.com/AlexsLemonade/refinebio/commit/0a4f00f441de1276c95bfb44882ea8462b422d22 to be deployed in order to work, but it won't fail if it isn't.

## Types of changes
* [x] New feature (non-breaking change which adds functionality)

## Functional tests

Check a dataset that failed when it was being processed.

## Checklist

* [x] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
* [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

![image](https://user-images.githubusercontent.com/1882507/46830947-fb8a2a00-cd6f-11e8-8594-60bdddfcb338.png)

