### PR TITLE
Add dropdown to sort search results

### DIFF
--- a/src/components/Dropdown/index.js
+++ b/src/components/Dropdown/index.js
@@ -5,7 +5,8 @@ const Dropdown = ({
   options = [],
   selectedOption = '',
   onChange,
-  disabled = false
+  disabled = false,
+  label = x => x
 }) => {
   return (
     <div className="dropdown">
@@ -24,7 +25,7 @@ const Dropdown = ({
         on the `onChange` handler */}
         {options.map((option, index) => (
           <option key={index} value={index}>
-            {option}
+            {label(option)}
           </option>
         ))}
       </select>

--- a/src/containers/Results/Results.scss
+++ b/src/containers/Results/Results.scss
@@ -11,6 +11,7 @@
     grid-template-areas:
       'top-bar'
       'side'
+      'action'
       'main';
 
     @include desktop {
@@ -51,6 +52,16 @@
 
     @include desktop {
       margin-bottom: 24px;
+    }
+  }
+
+  &__add-samples {
+    grid-area: action;
+    margin-bottom: 16px;
+
+    @include tablet {
+      grid-area: top-bar;
+      margin-left: auto;
     }
   }
 
@@ -122,10 +133,15 @@
   }
 
   &__number-results {
-    margin-bottom: 16px;
+    line-height: 32px;
 
     @include tablet {
-      margin-bottom: 0;
+      line-height: inherit;
+    }
+
+    > div {
+      display: inline-block;
+      margin-right: 24px;
     }
   }
 }

--- a/src/containers/Results/index.js
+++ b/src/containers/Results/index.js
@@ -119,7 +119,8 @@ class Results extends Component {
                     <NumberOfResults />
                     <OrderingDropdown />
                   </div>
-
+                </div>
+                <div className="results__add-samples">
                   <DataSetSampleActions
                     data={this._getSamplesAsDataSet()}
                     enableAddRemaining={false}

--- a/src/containers/Results/index.js
+++ b/src/containers/Results/index.js
@@ -19,7 +19,11 @@ import DataSetSampleActions from '../Experiment/DataSetSampleActions';
 import isEqual from 'lodash/isEqual';
 import Loader from '../../components/Loader';
 import Button from '../../components/Button';
-import { clearFilters } from '../../state/search/actions';
+import {
+  clearFilters,
+  Ordering,
+  updateOrdering
+} from '../../state/search/actions';
 import Spinner from '../../components/Spinner';
 
 class Results extends Component {
@@ -45,7 +49,8 @@ class Results extends Component {
       this.props.results &&
       this.props.results.length > 0 &&
       searchArgs.query === this.props.searchTerm &&
-      isEqual(searchArgs.filters, this.props.appliedFilters)
+      isEqual(searchArgs.filters, this.props.appliedFilters) &&
+      searchArgs.ordering === this.props.ordering
     ) {
       return;
     }
@@ -112,6 +117,7 @@ class Results extends Component {
                 <div className="results__top-bar">
                   <div className="results__number-results">
                     <NumberOfResults />
+                    <OrderingDropdown />
                   </div>
 
                   <DataSetSampleActions
@@ -150,7 +156,7 @@ class Results extends Component {
   }
 
   _parseUrl() {
-    let { q: query, p: page, size, ...filters } = getQueryParamObject(
+    let { q: query, p: page, size, ordering, ...filters } = getQueryParamObject(
       this.props.location.search
     );
 
@@ -168,7 +174,7 @@ class Results extends Component {
     page = parseInt(page || 1, 10);
     size = parseInt(size || 10, 10);
 
-    return { query, page, size, filters };
+    return { query, page, size, ordering, filters };
   }
 
   _getSamplesAsDataSet() {
@@ -185,7 +191,14 @@ class Results extends Component {
 }
 Results = connect(
   ({
-    search: { results, pagination, searchTerm, isSearching, appliedFilters },
+    search: {
+      results,
+      pagination,
+      searchTerm,
+      isSearching,
+      appliedFilters,
+      ordering
+    },
     download: { dataSet }
   }) => ({
     results,
@@ -193,7 +206,8 @@ Results = connect(
     searchTerm,
     dataSet,
     isLoading: isSearching,
-    appliedFilters
+    appliedFilters,
+    ordering
   }),
   {
     ...resultsActions,
@@ -294,3 +308,34 @@ NoSearchResultsTooManyFilters = connect(
     clearFilters
   }
 )(NoSearchResultsTooManyFilters);
+
+let OrderingDropdown = ({ ordering, updateOrdering }) => {
+  const options = [
+    { label: 'Most No. of samples', value: Ordering.MostSamples },
+    { label: 'Least No. of samples', value: Ordering.LeastSamples },
+    { label: 'Newest Experiment First', value: Ordering.Newest },
+    { label: 'Oldest Experiment First', value: Ordering.Oldest }
+  ];
+
+  const selectedOption = options.find(x => x.value === ordering) || options[0];
+
+  return (
+    <div className="">
+      Sort by{' '}
+      <Dropdown
+        options={options}
+        selectedOption={selectedOption}
+        label={x => x.label}
+        onChange={x => updateOrdering(x.value)}
+      />
+    </div>
+  );
+};
+OrderingDropdown = connect(
+  ({ search: { ordering } }) => ({
+    ordering
+  }),
+  {
+    updateOrdering
+  }
+)(OrderingDropdown);

--- a/src/state/search/actions.js
+++ b/src/state/search/actions.js
@@ -5,10 +5,10 @@ import reportError from '../reportError';
 export const MOST_SAMPLES = 'MostSamples';
 
 export const Ordering = {
-  MostSamples: '',
+  MostSamples: '', // default sorting, so no parameters needed
   LeastSamples: 'samples_count',
-  Newest: 'created_at',
-  Oldest: '-created_at'
+  Newest: '-source_first_published',
+  Oldest: 'source_first_published'
 };
 
 // This action updates the current search url with new paramters, which in turn triggers a call

--- a/src/state/search/actions.js
+++ b/src/state/search/actions.js
@@ -2,17 +2,27 @@ import { push } from '../routerActions';
 import { getQueryString, Ajax } from '../../common/helpers';
 import reportError from '../reportError';
 
+export const MOST_SAMPLES = 'MostSamples';
+
+export const Ordering = {
+  MostSamples: '',
+  LeastSamples: 'samples_count',
+  Newest: 'created_at',
+  Oldest: '-created_at'
+};
+
 // This action updates the current search url with new paramters, which in turn triggers a call
 // to `fethResults` from the view. Components wanting to modify the search results should call this
 // (or an action that call this) in order to update the search page. This way we ensure the flow is
 // in a single direction, for example:
 // new seach term -> triggers url change -> call fetchResults -> updates page
 // Without this it's harder to keep the url in sync with the results.
-const navigateToResults = ({ query, page, size, filters }) => {
+const navigateToResults = ({ query, page, size, filters, ordering }) => {
   const urlParams = {
     q: query,
     p: page > 1 ? page : undefined,
     size: size !== 10 ? size : undefined,
+    ordering: ordering !== Ordering.MostSamples ? ordering : undefined,
     ...filters
   };
 
@@ -21,7 +31,13 @@ const navigateToResults = ({ query, page, size, filters }) => {
   });
 };
 
-export function fetchResults({ query, page = 1, size = 10, filters }) {
+export function fetchResults({
+  query,
+  page = 1,
+  size = 10,
+  ordering = Ordering.MostSamples,
+  filters
+}) {
   return async (dispatch, getState) => {
     try {
       const {
@@ -32,6 +48,7 @@ export function fetchResults({ query, page = 1, size = 10, filters }) {
         ...(query ? { search: query } : {}),
         limit: size,
         offset: (page - 1) * size,
+        ...(ordering !== Ordering.MostSamples ? { ordering } : {}),
         ...filters
       });
 
@@ -42,6 +59,7 @@ export function fetchResults({ query, page = 1, size = 10, filters }) {
           results,
           filters: filterData,
           totalResults,
+          ordering,
 
           // these values come from the url, and are stored in redux after each search
           // to ease performing new searches from the action creators. Changes in the filters for
@@ -67,7 +85,8 @@ export const triggerSearch = searchTerm => (dispatch, getState) => {
       query: searchTerm,
       page: 1,
       filters: {},
-      size: resultsPerPage
+      size: resultsPerPage,
+      ordering: Ordering.MostSamples
     })
   );
 };
@@ -87,6 +106,7 @@ export function toggledFilter(filterType, filterValue) {
 export const updateFilters = newFilters => (dispatch, getState) => {
   const {
     searchTerm,
+    ordering,
     pagination: { resultsPerPage }
   } = getState().search;
   // reset to the first page when a filter is applied
@@ -95,7 +115,8 @@ export const updateFilters = newFilters => (dispatch, getState) => {
       query: searchTerm,
       page: 1,
       filters: newFilters,
-      size: resultsPerPage
+      size: resultsPerPage,
+      ordering
     })
   );
 };
@@ -105,11 +126,31 @@ export const clearFilters = () => dispatch => {
   dispatch(updateFilters(newFilters));
 };
 
+export const updateOrdering = newOrdering => (dispatch, getState) => {
+  const {
+    searchTerm,
+    appliedFilters,
+    pagination: { resultsPerPage }
+  } = getState().search;
+
+  // reset to the first page when a filter is applied
+  dispatch(
+    navigateToResults({
+      query: searchTerm,
+      page: 1,
+      filters: appliedFilters,
+      size: resultsPerPage,
+      ordering: newOrdering
+    })
+  );
+};
+
 export function updatePage(page) {
   return async (dispatch, getState) => {
     const {
       searchTerm,
       appliedFilters,
+      ordering,
       pagination: { resultsPerPage }
     } = getState().search;
     dispatch(
@@ -117,6 +158,7 @@ export function updatePage(page) {
         query: searchTerm,
         page,
         filters: appliedFilters,
+        ordering,
         size: resultsPerPage
       })
     );
@@ -129,6 +171,7 @@ export const updateResultsPerPage = resultsPerPage => async (
 ) => {
   const {
     searchTerm,
+    ordering,
     appliedFilters,
     pagination: { currentPage }
   } = getState().search;
@@ -136,6 +179,7 @@ export const updateResultsPerPage = resultsPerPage => async (
     navigateToResults({
       query: searchTerm,
       page: currentPage,
+      ordering,
       filters: appliedFilters,
       size: resultsPerPage
     })

--- a/src/state/search/actions.js
+++ b/src/state/search/actions.js
@@ -6,7 +6,7 @@ export const MOST_SAMPLES = 'MostSamples';
 
 export const Ordering = {
   MostSamples: '', // default sorting, so no parameters needed
-  LeastSamples: 'samples_count',
+  LeastSamples: 'total_samples_count',
   Newest: '-source_first_published',
   Oldest: 'source_first_published'
 };

--- a/src/state/search/reducer.js
+++ b/src/state/search/reducer.js
@@ -21,7 +21,8 @@ export default (state = initialState, action) => {
         totalResults,
         currentPage,
         appliedFilters,
-        resultsPerPage
+        resultsPerPage,
+        ordering
       } = action.data;
 
       const totalPages = Math.ceil(
@@ -34,6 +35,7 @@ export default (state = initialState, action) => {
         results,
         filters,
         appliedFilters,
+        ordering,
         pagination: {
           ...state.pagination,
           totalResults,


### PR DESCRIPTION
## Issue Number

close #372 

## Purpose/Implementation Notes

Adds a dropdown to allow the user to sort the experiments. The parameters send on each case to the API are:

https://github.com/AlexsLemonade/refinebio-frontend/blob/5db9042ad346182b5ba551914c073c994aea4131/src/state/search/actions.js#L8-L11

This needs https://github.com/AlexsLemonade/refinebio/pull/725 to be merged in the backend, but it won't fail if it isn't.

## Types of changes

* [x] New feature (non-breaking change which adds functionality)

## Functional tests

Search/Sort

## Checklist

* [x] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
* [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

![2018-10-15 12 49 45](https://user-images.githubusercontent.com/1882507/46965432-d69bfc80-d078-11e8-94bb-ea0993062782.gif)

And the parameters sent to the API

![image](https://user-images.githubusercontent.com/1882507/46965455-eb789000-d078-11e8-8405-05a05a958774.png)


