### PR TITLE
Cosmetics for table

### DIFF
--- a/src/common/styles/_variables.scss
+++ b/src/common/styles/_variables.scss
@@ -56,9 +56,7 @@ $check-disabled: #f2f2f2;
 
 // TABLE
 $table-header-background: #cacaca;
-$table-header-border-color: #979797;
-
-$table-border-color: #979797;
+$table-border-color: #ccc;
 
 $table-row--highlight: #f2f2f2;
 

--- a/src/containers/Experiment/Experiment.scss
+++ b/src/containers/Experiment/Experiment.scss
@@ -5,7 +5,17 @@
   background-color: $white;
   box-shadow: 0 3px 20px 0 rgba(0, 0, 0, 0.1);
   padding: 24px;
-  margin: 32px 0 80px;
+  margin: 32px 0 40px;
+
+  &--sample-wrap {
+    @extend .experiment;
+    margin-bottom: 80px;
+
+    @media (min-width: 1290px) {
+      margin-left: -80px;
+      margin-right: -80px;
+    }
+  }
 
   &__header-title {
     @include tablet {

--- a/src/containers/Experiment/SampleFieldMetadata.js
+++ b/src/containers/Experiment/SampleFieldMetadata.js
@@ -12,7 +12,8 @@ const SampleFieldMetadata = [
     Header: 'Accession Code',
     id: 'accession_code',
     accessor: d => d.accession_code,
-    minWidth: 160
+    minWidth: 160,
+    width: 175
   },
   {
     Header: 'Sex',

--- a/src/containers/Experiment/SampleFieldMetadata.js
+++ b/src/containers/Experiment/SampleFieldMetadata.js
@@ -13,7 +13,8 @@ const SampleFieldMetadata = [
     id: 'accession_code',
     accessor: d => d.accession_code,
     minWidth: 160,
-    width: 175
+    width: 175,
+    style: { textAlign: 'right' }
   },
   {
     Header: 'Sex',

--- a/src/containers/Experiment/SamplesTable.js
+++ b/src/containers/Experiment/SamplesTable.js
@@ -224,13 +224,15 @@ class SamplesTable extends React.Component {
         Header: 'Processing Information',
         id: 'processing_information',
         sortable: false,
-        Cell: ProcessingInformationCell
+        Cell: ProcessingInformationCell,
+        width: 200
       },
       {
         Header: 'Additional Metadata',
         id: 'additional_metadata',
         sortable: false,
-        Cell: MetadataCell
+        Cell: MetadataCell,
+        width: 200
       }
     ];
 

--- a/src/containers/Experiment/SamplesTable.scss
+++ b/src/containers/Experiment/SamplesTable.scss
@@ -34,6 +34,7 @@
 .samples-table {
   height: 100%;
   max-height: 115 * 8px;
+  border-color: $table-border-color;
 
   &__th {
     // The original styles for headers in ReactTable are under the selector: .ReactTable .rt-thead .rt-th.-sort-asc
@@ -60,6 +61,20 @@
       overflow-y: scroll; /* has to be scroll, not auto */
       -webkit-overflow-scrolling: touch;
     }
+
+    .rt-td,
+    .rt-tr-group {
+      border-color: $table-border-color;
+    }
+  }
+
+  .rt-thead {
+    .rt-td,
+    .rt-th {
+      border-color: $table-border-color;
+      border-bottom-style: solid;
+      border-bottom-width: 1px;
+    }
   }
 
   .rt-noData {
@@ -70,6 +85,7 @@
     flex-direction: column;
     margin-left: 8px;
     display: none;
+    color: #8d8d8d;
 
     .rt-th.-cursor-pointer & {
       display: flex;
@@ -117,7 +133,7 @@
 
   // override styles of the original table components
   .rt-td {
-    padding: 4px 8px !important;
+    padding: 8px 16px !important;
     white-space: normal !important;
   }
 

--- a/src/containers/Experiment/index.js
+++ b/src/containers/Experiment/index.js
@@ -224,17 +224,18 @@ let Experiment = ({
                   </div>
                 </div>
               </div>
+            </div>
+
+            <div className="experiment experiment--sample-wrap">
               <Anchor name="samples">
-                <section className="experiment__section">
-                  <h2 className="experiment__title">Samples</h2>
-                  {isLoading ? (
-                    <div className="experiment__sample-table-loading-wrap">
-                      <Spinner />
-                    </div>
-                  ) : (
-                    <ExperimentSamplesTable experiment={experimentData} />
-                  )}
-                </section>
+                <h2 className="experiment__title">Samples</h2>
+                {isLoading ? (
+                  <div className="experiment__sample-table-loading-wrap">
+                    <Spinner />
+                  </div>
+                ) : (
+                  <ExperimentSamplesTable experiment={experimentData} />
+                )}
               </Anchor>
             </div>
           </div>


### PR DESCRIPTION
## Issue Number

close #365 

## Purpose/Implementation Notes

This adds all cosmetic recommendations https://github.com/AlexsLemonade/refinebio-frontend/issues/365#issuecomment-429107314 for the table, except for two:

1. Filtering samples. Support in the backend will be added with https://github.com/AlexsLemonade/refinebio/pull/737. I'll add a new issue to keep track of this.

2. Partially show last column. I couldn't find a non ugly/hacky way to get this done. Although with the current column widths this will happen for most users.

## Types of changes

* [x] New feature (non-breaking change which adds functionality)

## Functional tests

Check samples table on different resolutions.

## Checklist

* [x] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
* [x] Any dependent changes have been merged and published in downstream modules

## Screenshots

![image](https://user-images.githubusercontent.com/1882507/47030229-4d013300-d13b-11e8-8822-f5278d66d71b.png)

![image](https://user-images.githubusercontent.com/1882507/47030208-41157100-d13b-11e8-85da-0b30e6eadb8f.png)
