### PR TITLE
Refactor search endpoint to expect all samples

### DIFF
--- a/src/containers/Experiment/Technology.js
+++ b/src/containers/Experiment/Technology.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import TechnologyBadge, {
+  MICROARRAY,
+  RNA_SEQ
+} from '../../components/TechnologyBadge';
+import uniq from 'lodash/uniq';
+
+export default function Technology({ samples }) {
+  return (
+    <React.Fragment>
+      <TechnologyBadge
+        className="experiment__stats-icon"
+        isMicroarray={samples.some(x => x.technology === MICROARRAY)}
+        isRnaSeq={samples.some(x => x.technology === RNA_SEQ)}
+      />
+      {uniq(samples.map(x => x.pretty_platform)).join(', ')}
+    </React.Fragment>
+  );
+}

--- a/src/containers/Experiment/index.js
+++ b/src/containers/Experiment/index.js
@@ -25,6 +25,8 @@ import TechnologyBadge, {
 import Spinner from '../../components/Spinner';
 import ScrollTopOnMount from '../../components/ScrollTopOnMount';
 import Anchor from '../../components/Anchor';
+import uniq from 'lodash/uniq';
+import Technology from './Technology';
 
 let Experiment = ({
   fetchExperiment,
@@ -109,25 +111,10 @@ let Experiment = ({
                       }`
                     : null}
                 </div>
-                {!isLoading &&
-                  experimentData.samples.length && (
-                    <div className="experiment__stats-item">
-                      <TechnologyBadge
-                        className="experiment__stats-icon"
-                        isMicroarray={experimentData.samples.some(
-                          x => x.technology === MICROARRAY
-                        )}
-                        isRnaSeq={experimentData.samples.some(
-                          x => x.technology === RNA_SEQ
-                        )}
-                      />
-                      {[
-                        ...new Set(
-                          experimentData.samples.map(x => x.pretty_platform)
-                        )
-                      ].join(', ')}
-                    </div>
-                  )}
+
+                <div className="experiment__stats-item">
+                  <Technology samples={experimentData.samples} />
+                </div>
               </div>
 
               <h4 className="experiment__title">

--- a/src/containers/Results/Result/index.js
+++ b/src/containers/Results/Result/index.js
@@ -10,11 +10,18 @@ import TechnologyBadge, {
   MICROARRAY,
   RNA_SEQ
 } from '../../../components/TechnologyBadge';
-
+import DataSetStats from '../../Experiment/DataSetStats';
+import SampleFieldMetadata from '../../Experiment/SampleFieldMetadata';
+import Technology from '../../Experiment/Technology';
 import * as routes from '../../../routes';
 
 const Result = ({ result, query }) => {
-  const metadataFields = getMetadataFields(result);
+  const metadataFields =
+    !result.samples || result.samples.length === 0
+      ? []
+      : SampleFieldMetadata.filter(field =>
+          result.samples.some(sample => !!sample[field.id])
+        ).map(field => field.Header);
 
   return (
     <div className="result">
@@ -41,7 +48,7 @@ const Result = ({ result, query }) => {
 
         <DataSetSampleActions
           dataSetSlice={{
-            [result.accession_code]: result.processed_samples
+            [result.accession_code]: DataSetStats.mapAccessions(result.samples)
           }}
         />
       </div>
@@ -60,21 +67,12 @@ const Result = ({ result, query }) => {
           <img src={SampleIcon} className="result__icon" alt="sample-icon" />{' '}
           {result.samples.length
             ? `${result.samples.length} Sample${
-                result.samples.length > 1 ? 's' : null
+                result.samples.length > 1 ? 's' : ''
               }`
-            : null}
+            : ''}
         </li>
         <li className="result__stat">
-          <TechnologyBadge
-            className="result__icon"
-            isMicroarray={
-              result.technologies && result.technologies.includes(MICROARRAY)
-            }
-            isRnaSeq={
-              result.technologies && result.technologies.includes(RNA_SEQ)
-            }
-          />
-          {result.pretty_platforms.filter(platform => !!platform).join(', ')}
+          <Technology samples={result.samples} />
         </li>
       </ul>
 

--- a/src/containers/Results/index.js
+++ b/src/containers/Results/index.js
@@ -26,6 +26,7 @@ import {
   updateResultsPerPage
 } from '../../state/search/actions';
 import fromPairs from 'lodash/fromPairs';
+import DataSetStats from '../Experiment/DataSetStats';
 
 class Results extends Component {
   state = {
@@ -180,7 +181,10 @@ export default Results;
 function AddPageToDataSetButton({ results }) {
   // create a dataset slice with the results, use the accession codes in `processed_samples`
   const resultsDataSetSlice = fromPairs(
-    results.map(result => [result.accession_code, result.processed_samples])
+    results.map(result => [
+      result.accession_code,
+      DataSetStats.mapAccessions(result.samples)
+    ])
   );
 
   return (


### PR DESCRIPTION
## Issue Number

close #391 
https://github.com/AlexsLemonade/refinebio/pull/736

## Purpose/Implementation Notes

https://github.com/AlexsLemonade/refinebio/pull/736 changed the API to send all samples with each result. This updated the front-end accordingly.

**Important** Once this gets merged, the `dev` branch will stop working with api.refine.bio until https://github.com/AlexsLemonade/refinebio/pull/736 is deployed.

## Types of changes

* [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

Check search page.

## Checklist

* [x] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
* [x] Any dependent changes have been merged and **BUT NOT** published in downstream modules

## Screenshots

![image](https://user-images.githubusercontent.com/1882507/47098737-cc593a00-d201-11e8-9ef7-7f6cad021586.png)

