### PR TITLE
Prefer RNA-Seq over RNA-seq

### DIFF
--- a/src/containers/Experiment/ProcessingInformation/ProcessingInformationModalContent.js
+++ b/src/containers/Experiment/ProcessingInformation/ProcessingInformationModalContent.js
@@ -203,7 +203,7 @@ function SalmonProtocol() {
       <h3>Salmon</h3>
       <p>
         Salmon is an alignment-free method for estimating transcript abundances
-        from RNA-seq data. We use it in quasi-mapping mode, which is
+        from RNA-Seq data. We use it in quasi-mapping mode, which is
         significantly faster than alignment-based approaches and requires us to
         build a Salmon transcriptome index. We build a custom reference
         transcriptome (using RSEM rsem-prepare-reference) by filtering the

--- a/src/containers/Main/index.js
+++ b/src/containers/Main/index.js
@@ -52,7 +52,7 @@ let Main = ({ searchTerm, fetchResults, push }) => {
               Find the data you need
             </h3>
             <p className="main__paragraph">
-              Search the collection of harmonized RNA-seq and microarray data
+              Search the collection of harmonized RNA-Seq and microarray data
               from publicly available sources like GEO, ArrayExpress, and SRA.
               The data has been processed with a set of standardized pipelines
               curated by the{' '}


### PR DESCRIPTION
Trivial, but this appears to be the proper usage (at least according to Wikipedia).