### PR TITLE
Hide additional metadata column when its all empty

### DIFF
--- a/src/containers/Experiment/SamplesTable.js
+++ b/src/containers/Experiment/SamplesTable.js
@@ -231,7 +231,10 @@ class SamplesTable extends React.Component {
         id: 'additional_metadata',
         sortable: false,
         Cell: MetadataAnnotationsCell,
-        width: 200
+        width: 200,
+        show: data.some(
+          sample => !!sample.annotations && sample.annotations.length > 0
+        )
       }
     ];
 


### PR DESCRIPTION
## Issue Number

close #397 

## Purpose/Implementation Notes

Hide additional metadata column when its all empty

## Screenshots


![image](https://user-images.githubusercontent.com/1882507/47573551-9c99e880-d90b-11e8-85cc-732b6d8a1c04.png)
