### PR TITLE
Disable offline-first

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,15 +3,12 @@ import ReactDOM from 'react-dom';
 import './index.scss';
 import App from './components/App';
 
-import registerServiceWorker from './registerServiceWorker';
+import { unregister } from './registerServiceWorker';
 
 import smoothscroll from 'smoothscroll-polyfill';
 
 // kick off the polyfill!
 smoothscroll.polyfill();
-
-ReactDOM.render(<App />, document.getElementById('root'));
-registerServiceWorker();
 
 declare var Raven: any;
 
@@ -20,7 +17,14 @@ function initApp() {
   document.querySelector('meta[name="description"]').remove();
 
   ReactDOM.render(<App />, document.getElementById('root'));
-  registerServiceWorker();
+
+  // Disable service worker https://github.com/facebook/create-react-app/issues/2715#issuecomment-313171863
+  // By default apps created with `create-react-app` (before v2.0.0) were offline first.
+  // This means that after the first visit, a cached version of the app is always served first
+  // In our case we want the latest version to always be served, and we don't need the app
+  // to work offline.
+  // More details at https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app
+  unregister();
 }
 
 if (process.env.NODE_ENV === 'development') {


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio-frontend/issues/149

## Purpose/Implementation Notes

refine.bio was set up to work offline as a [progressive web app](https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app). This meant that we always served a cached version of the app if existed when an user visited the page.

This PR disables this behavior and ensures the latest version is always served.

## Types of changes

* [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

Tested locally, we need to test this on staging.
