### PR TITLE
WIP Use real number in about page

### DIFF
--- a/src/common/helpers.js
+++ b/src/common/helpers.js
@@ -204,3 +204,30 @@ export function accumulateByKeys(array, keys) {
     }, {})
   }));
 }
+
+/**
+ * numberFormatter(33000) = '33K'
+ *
+ * Thanks to https://stackoverflow.com/a/14994860/763705
+ * @param {*} num
+ * @param {*} digits
+ */
+export function numberFormatter(num, digits = 0) {
+  var si = [
+    { value: 1, symbol: '' },
+    { value: 1e3, symbol: 'k' },
+    { value: 1e6, symbol: 'M' },
+    { value: 1e9, symbol: 'G' },
+    { value: 1e12, symbol: 'T' },
+    { value: 1e15, symbol: 'P' },
+    { value: 1e18, symbol: 'E' }
+  ];
+  var rx = /\.0+$|(\.[0-9]*[1-9])0+$/;
+  var i;
+  for (i = si.length - 1; i > 0; i--) {
+    if (num >= si[i].value) {
+      break;
+    }
+  }
+  return (num / si[i].value).toFixed(digits).replace(rx, '$1') + si[i].symbol;
+}

--- a/src/components/About/index.js
+++ b/src/components/About/index.js
@@ -48,7 +48,8 @@ function About() {
                   {numberFormatter(apiData.stats.samples.total)}
                 </div>
                 <div className="about__stat-text">
-                  1.5 million samples will be available
+                  {numberFormatter(apiData.stats.samples.total)} samples
+                  available
                 </div>
               </div>
               <div className="about__stat-item">
@@ -56,13 +57,15 @@ function About() {
                   {numberFormatter(Object.keys(apiData.organism).length)}
                 </div>
                 <div className="about__stat-text">
-                  There will be support for 3000 organisms
+                  Support for{' '}
+                  {numberFormatter(Object.keys(apiData.organism).length)}{' '}
+                  organisms
                 </div>
               </div>
               <div className="about__stat-item">
-                <div className="about__stat">1 PB</div>
+                <div className="about__stat">11.7 TB</div>
                 <div className="about__stat-text">
-                  Over a petabyte of raw data will be processed
+                  11.7 terabytes of raw data processed
                 </div>
               </div>
             </div>

--- a/src/components/About/index.js
+++ b/src/components/About/index.js
@@ -10,6 +10,9 @@ import betterMed from './better-med.svg';
 import alsfLogo from './ALSFsquare.jpg';
 import ccdlLogo from './CCDL-logo.jpg';
 
+import apiData from '../../apiData.json';
+import { numberFormatter } from '../../common/helpers';
+
 function About() {
   return (
     <div>
@@ -41,13 +44,17 @@ function About() {
 
             <div className="about__stats-list">
               <div className="about__stat-item">
-                <div className="about__stat">1.5M</div>
+                <div className="about__stat">
+                  {numberFormatter(apiData.stats.samples.total)}
+                </div>
                 <div className="about__stat-text">
                   1.5 million samples will be available
                 </div>
               </div>
               <div className="about__stat-item">
-                <div className="about__stat">3K</div>
+                <div className="about__stat">
+                  {numberFormatter(Object.keys(apiData.organism).length)}
+                </div>
                 <div className="about__stat-text">
                   There will be support for 3000 organisms
                 </div>


### PR DESCRIPTION
This is work in progress, requires https://github.com/AlexsLemonade/refinebio/issues/768. And also we need to update the copy on the about page, to reflect that we're displaying real numbers.

## Issue Number

#320 

## Purpose/Implementation Notes

Use real numbers in about page.

## Types of changes

* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

List out the functional tests you've completed to verify your changes work locally.

## Checklist

* [x] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
* [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

![image](https://user-images.githubusercontent.com/1882507/48212894-9283db00-e34a-11e8-8a07-8a2c1e1f2df3.png)
