### PR TITLE
Count the number of samples after filtering

### DIFF
--- a/src/api/samples.js
+++ b/src/api/samples.js
@@ -23,7 +23,7 @@ export async function getAllDetailedSamples({
   filterBy
 }) {
   if (accessionCodes && accessionCodes.length) {
-    let { results } = await Ajax.get('/samples/', {
+    let { count, results } = await Ajax.get('/samples/', {
       // send the accession codes as a string, otherwise they will be converted to an array parameter
       accession_codes: accessionCodes.join(','),
       offset,
@@ -31,7 +31,7 @@ export async function getAllDetailedSamples({
       order_by: orderBy,
       filter_by: filterBy || undefined // don't send the parameter  if `filterBy === ''`
     });
-    return results;
+    return { count, data: results };
   } else {
     return [];
   }

--- a/src/containers/Experiment/SamplesTable.js
+++ b/src/containers/Experiment/SamplesTable.js
@@ -28,6 +28,7 @@ class SamplesTable extends React.Component {
     pages: -1,
     pageSize: 10,
     columns: this._getColumns(),
+    totalSamples: 0,
     data: [],
     filter: ''
   };
@@ -46,7 +47,7 @@ class SamplesTable extends React.Component {
   }
 
   get totalSamples() {
-    return this._getSampleAccessionCodes().length;
+    return this.state.totalSamples;
   }
 
   render() {
@@ -157,7 +158,7 @@ class SamplesTable extends React.Component {
 
     let offset = page * pageSize;
 
-    let data = await getAllDetailedSamples({
+    let { count, data } = await getAllDetailedSamples({
       accessionCodes,
       orderBy,
       offset,
@@ -181,6 +182,7 @@ class SamplesTable extends React.Component {
     let columns = this._getColumns(data);
 
     this.setState({
+      totalSamples: count,
       data,
       page,
       columns,


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

When filtering samples, the pagination and the total number of samples displayed wasn't being updated.

## Types of changes

* [x] Bugfix (non-breaking change which fixes an issue)

## Functional tests

Filter on samples table

## Checklist

* [x] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
* [x] Any dependent changes have been merged and published in downstream modules

## Screenshots

![2018-11-09 14 48 03](https://user-images.githubusercontent.com/1882507/48284787-7eb1a500-e42e-11e8-860c-0ce6f98802d8.gif)

