### PR TITLE
Ensure infobox is only displayed if the user lands on experiments page

### DIFF
--- a/src/components/InfoBox.js
+++ b/src/components/InfoBox.js
@@ -44,6 +44,8 @@ function InfoBoxMobile({ onClose }) {
 
 const VISITED_BEFORE = 'firstTimeVisitor';
 
+const LANDING_PAGE = window.location.href;
+
 /**
  * Returns true if this is the first time a user is visiting us
  */
@@ -57,7 +59,8 @@ function firstTimeUser() {
 
 class InfoBox extends React.Component {
   state = {
-    showInfoBox: firstTimeUser()
+    // The infobox should only be displayed when it's first loaded, on the page where the user landed initially
+    showInfoBox: firstTimeUser() && LANDING_PAGE === window.location.href
   };
 
   render() {


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio-frontend/issues/348

## Purpose/Implementation Notes

Noticed a bug, that caused the infobox to be displayed for new users that land on the home page and make a search. 

This PR ensures the infobox is only displayed for users that land on the search results or the experiments pages.

## Types of changes

* [x] Bugfix (non-breaking change which fixes an issue)

## Functional tests

Check infobox in anonymous session.

## Checklist

* [x] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
* [x] Any dependent changes have been merged and published in downstream modules

