### PR TITLE
Adds interactive filtering

### DIFF
--- a/src/containers/Results/ResultFilters/index.js
+++ b/src/containers/Results/ResultFilters/index.js
@@ -144,7 +144,7 @@ class FiltersMobile extends React.Component {
                   key={`${filterKey}${filterValue}`}
                   value={filterValue}
                   onClick={() =>
-                    this.props.toggledFilter(filterKey, filterValue)
+                    this.props.toggledFilter(filterKey, filterValue, false)
                   }
                 />
               ))

--- a/src/containers/Results/index.js
+++ b/src/containers/Results/index.js
@@ -164,6 +164,7 @@ class Results extends Component {
       p: page = 1,
       size = 10,
       ordering = '',
+      filter_order = '',
       ...filters
     } = getQueryParamObject(this.props.location.search);
 
@@ -180,8 +181,9 @@ class Results extends Component {
     query = query ? decodeURIComponent(query) : undefined;
     page = parseInt(page, 10);
     size = parseInt(size, 10);
+    const filterOrder = filter_order ? filter_order.split(',') : [];
 
-    return { query, page, size, ordering, filters };
+    return { query, page, size, ordering, filters, filterOrder };
   }
 }
 Results = connect(

--- a/src/state/search/actions.js
+++ b/src/state/search/actions.js
@@ -105,16 +105,24 @@ export const triggerSearch = searchTerm => (dispatch, getState) => {
   );
 };
 
-export function toggledFilter(filterType, filterValue) {
+/**
+ * Toggles a given filter
+ * @param {string} filterType Name of the filter to be applied
+ * @param {string} filterValue Value of the filter
+ * @param {boolean} trackOrder Allow disabling interactive filtering (used on mobile devices)
+ */
+export function toggledFilter(filterType, filterValue, trackOrder = true) {
   return (dispatch, getState) => {
     const { filters, filterOrder } = getUrlParams(getState());
     const newFilters = toggleFilterHelper(filters, filterType, filterValue);
-    const newFilterOrder = updateFilterOrderHelper({
-      filters,
-      type: filterType,
-      value: filterValue,
-      filterOrder
-    });
+    const newFilterOrder = trackOrder
+      ? updateFilterOrderHelper({
+          filters,
+          type: filterType,
+          value: filterValue,
+          filterOrder
+        })
+      : [];
 
     dispatch(updateFilters(newFilters, newFilterOrder));
   };

--- a/src/state/search/actions.js
+++ b/src/state/search/actions.js
@@ -1,6 +1,7 @@
 import { push } from '../routerActions';
 import { getQueryString, Ajax } from '../../common/helpers';
 import reportError from '../reportError';
+import { getUrlParams } from './reducer';
 
 export const MOST_SAMPLES = 'MostSamples';
 
@@ -76,16 +77,15 @@ export function fetchResults({
 }
 
 export const triggerSearch = searchTerm => (dispatch, getState) => {
-  const {
-    pagination: { resultsPerPage }
-  } = getState().search;
+  const params = getUrlParams(getState());
+
   // when a new search is performed, remove the filters, and go back to the first page
   dispatch(
     navigateToResults({
+      ...params,
       query: searchTerm,
       page: 1,
       filters: {},
-      size: resultsPerPage,
       ordering: Ordering.MostSamples
     })
   );
@@ -104,19 +104,14 @@ export function toggledFilter(filterType, filterValue) {
 }
 
 export const updateFilters = newFilters => (dispatch, getState) => {
-  const {
-    searchTerm,
-    ordering,
-    pagination: { resultsPerPage }
-  } = getState().search;
+  const params = getUrlParams(getState());
+
   // reset to the first page when a filter is applied
   dispatch(
     navigateToResults({
-      query: searchTerm,
+      ...params,
       page: 1,
-      filters: newFilters,
-      size: resultsPerPage,
-      ordering
+      filters: newFilters
     })
   );
 };
@@ -127,60 +122,37 @@ export const clearFilters = () => dispatch => {
 };
 
 export const updateOrdering = newOrdering => (dispatch, getState) => {
-  const {
-    searchTerm,
-    appliedFilters,
-    pagination: { resultsPerPage }
-  } = getState().search;
+  const params = getUrlParams(getState());
 
   // reset to the first page when a filter is applied
   dispatch(
     navigateToResults({
-      query: searchTerm,
+      ...params,
       page: 1,
-      filters: appliedFilters,
-      size: resultsPerPage,
       ordering: newOrdering
     })
   );
 };
 
-export function updatePage(page) {
-  return async (dispatch, getState) => {
-    const {
-      searchTerm,
-      appliedFilters,
-      ordering,
-      pagination: { resultsPerPage }
-    } = getState().search;
-    dispatch(
-      navigateToResults({
-        query: searchTerm,
-        page,
-        filters: appliedFilters,
-        ordering,
-        size: resultsPerPage
-      })
-    );
-  };
-}
+export const updatePage = page => async (dispatch, getState) => {
+  const params = getUrlParams(getState());
+
+  dispatch(
+    navigateToResults({
+      ...params,
+      page
+    })
+  );
+};
 
 export const updateResultsPerPage = resultsPerPage => async (
   dispatch,
   getState
 ) => {
-  const {
-    searchTerm,
-    ordering,
-    appliedFilters,
-    pagination: { currentPage }
-  } = getState().search;
+  const params = getUrlParams(getState());
   dispatch(
     navigateToResults({
-      query: searchTerm,
-      page: currentPage,
-      ordering,
-      filters: appliedFilters,
+      ...params,
       size: resultsPerPage
     })
   );

--- a/src/state/search/actions.test.js
+++ b/src/state/search/actions.test.js
@@ -1,4 +1,4 @@
-import { toggleFilterHelper } from './actions';
+import { toggleFilterHelper, updateFilterOrderHelper } from './actions';
 
 describe('toggleFilterHelper', () => {
   it('adds filter when none selected', () => {
@@ -17,5 +17,40 @@ describe('toggleFilterHelper', () => {
     let filters = { name: ['value1', 'value2'] };
     let toggled = toggleFilterHelper(filters, 'name', 'value2');
     expect(toggled).toEqual({ name: ['value1'] });
+  });
+});
+
+describe('updateFilterOrderHelper', () => {
+  it('adds new filter', () => {
+    let filters = { name: ['value1'] };
+    let newOrder = updateFilterOrderHelper({
+      filters,
+      filterOrder: [],
+      type: 'name',
+      value: 'value0'
+    });
+    expect(newOrder).toEqual(['name']);
+  });
+
+  it('adds second category to filter order', () => {
+    let filters = { name: ['value1'] };
+    let newOrder = updateFilterOrderHelper({
+      filters,
+      filterOrder: ['name'],
+      type: 'name',
+      value: 'value0'
+    });
+    expect(newOrder).toEqual(['name', 'name']);
+  });
+
+  it('removes added filter', () => {
+    let filters = { name: ['value1'] };
+    let newOrder = updateFilterOrderHelper({
+      filters,
+      filterOrder: ['name'],
+      type: 'name',
+      value: 'value1'
+    });
+    expect(newOrder).toEqual([]);
   });
 });

--- a/src/state/search/reducer.js
+++ b/src/state/search/reducer.js
@@ -49,3 +49,15 @@ export default (state = initialState, action) => {
       return state;
   }
 };
+
+/**
+ * Returns the parameters from the url, that are saved in the state
+ * @param {*} param0 redux state
+ */
+export const getUrlParams = ({ search }) => ({
+  query: search.searchTerm,
+  page: search.pagination.currentPage,
+  size: search.pagination.resultsPerPage,
+  filters: search.appliedFilters,
+  ordering: search.ordering
+});

--- a/src/state/search/reducer.js
+++ b/src/state/search/reducer.js
@@ -2,6 +2,7 @@ const initialState = {
   searchTerm: '',
   results: [],
   filters: {},
+  filterOrder: [],
   appliedFilters: {},
   pagination: {
     totalResults: 0,
@@ -21,6 +22,7 @@ export default (state = initialState, action) => {
         totalResults,
         currentPage,
         appliedFilters,
+        filterOrder, // array with the name of the applied filters
         resultsPerPage,
         ordering
       } = action.data;
@@ -35,6 +37,7 @@ export default (state = initialState, action) => {
         results,
         filters,
         appliedFilters,
+        filterOrder,
         ordering,
         pagination: {
           ...state.pagination,
@@ -59,5 +62,6 @@ export const getUrlParams = ({ search }) => ({
   page: search.pagination.currentPage,
   size: search.pagination.resultsPerPage,
   filters: search.appliedFilters,
+  filterOrder: search.filterOrder,
   ordering: search.ordering
 });


### PR DESCRIPTION
## Issue Number

close #374 

## Purpose/Implementation Notes

Adds a new parameter on the URL `filter_order` to track the order of the filters. The modifications of the API are on https://github.com/AlexsLemonade/refinebio/pull/835

## Types of changes

* [x] New feature (non-breaking change which adds functionality)
* [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

Try using the filters and changing the order of the categories when they were applied.

## Checklist

* [x] Lint and unit tests pass locally with my changes
* [x] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
* [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

![2018-11-20 12 44 54](https://user-images.githubusercontent.com/1882507/48792396-25fdca00-ecc2-11e8-93c7-ef5973eca052.gif)
