### PR TITLE
Fix urls of keys on deploy script

### DIFF
--- a/.circleci/verify_tag.sh
+++ b/.circleci/verify_tag.sh
@@ -4,7 +4,7 @@
 # by a trusted member of the CCDL.
 
 for key in keys/*; do
-    gpg --import keys/$key
+    gpg --import $key
 done
 
 # If it is not a good key then the exit code is 1, which will cause


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio-frontend/pull/420

## Purpose/Implementation Notes

The last deploy failed because the paths to the gpg keys wasn't correct, this fixes it. CircleCI failed when importing the keys with the following error:

```
gpg: can't open 'keys/keys/ariel.gpg': No such file or directory
gpg: Total number processed: 0
gpg: can't open 'keys/keys/casey.gpg': No such file or directory
gpg: Total number processed: 0
gpg: can't open 'keys/keys/dongbo.gpg': No such file or directory
gpg: Total number processed: 0
gpg: can't open 'keys/keys/kurt.gpg': No such file or directory
gpg: Total number processed: 0
gpg: can't open 'keys/keys/rich.gpg': No such file or directory
gpg: Total number processed: 0
```

## Types of changes

* [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

* [x] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
* [x] Any dependent changes have been merged and published in downstream modules
