### PR TITLE
Reduce the amount of information that is sent with `pushState`

### DIFF
--- a/src/containers/Results/Result/index.js
+++ b/src/containers/Results/Result/index.js
@@ -37,7 +37,18 @@ const Result = ({ result, query }) => {
             className="link result__title"
             to={routes.experiments(result.accession_code, {
               ref: 'search',
-              result
+              result: {
+                accession_code: result.accession_code,
+                title: result.title,
+                description: result.description,
+                pubmed_id: result.pubmed_id,
+                publication_title: result.publication_title,
+                submitter_institution: result.submitter_institution,
+                publication_authors: result.publication_authors,
+                source_url: result.source_url,
+                source_database: result.source_database,
+                samples: []
+              }
             })}
           >
             {result.title ? (
@@ -114,7 +125,18 @@ const Result = ({ result, query }) => {
           className="button button--secondary"
           to={routes.experimentsSamples(result.accession_code, {
             ref: 'search',
-            result
+            result: {
+              accession_code: result.accession_code,
+              title: result.title,
+              description: result.description,
+              pubmed_id: result.pubmed_id,
+              publication_title: result.publication_title,
+              submitter_institution: result.submitter_institution,
+              publication_authors: result.publication_authors,
+              source_url: result.source_url,
+              source_database: result.source_database,
+              samples: []
+            }
           })}
         >
           View Samples


### PR DESCRIPTION
## Issue Number

Close #436 

## Purpose/Implementation Notes

When navigating to the experiments page, we are sending the result object attached to the state of the URL. Firefox [has a limit of 640kb](https://developer.mozilla.org/en-US/docs/Web/API/History_API#The_pushState()_method). 

Some experiments were bigger than 640kb, and that was making the navigation fail in FF.

Once https://github.com/AlexsLemonade/refinebio-frontend/pull/433 get's merged these objects will be smaller.

/cc @Miserlou 

## Types of changes

* [x] Bugfix (non-breaking change which fixes an issue)

## Functional tests

Search and navigate to experiments page.

## Checklist

* [x] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
* [x] Any dependent changes have been merged and published in downstream modules
