### PR TITLE
Refresh the app when the version of the api changes

### DIFF
--- a/cacheBackend.js
+++ b/cacheBackend.js
@@ -21,6 +21,9 @@ Promise.all([
   // fetch samples per organisms, also used on the landing page
   axios.get(ApiHost + '/search/?limit=1&offset=0').then(function(response) {
     cache['organism'] = response.data.filters.organism;
+
+    // also use this request to save the source revision returned in the headers
+    cache['sourceRevision'] = response.headers['x-source-revision'] || false;
   })
 ]).then(function() {
   fs.writeFileSync(`src/apiData.json`, JSON.stringify(cache));

--- a/cacheBackend.js
+++ b/cacheBackend.js
@@ -21,9 +21,6 @@ Promise.all([
   // fetch samples per organisms, also used on the landing page
   axios.get(ApiHost + '/search/?limit=1&offset=0').then(function(response) {
     cache['organism'] = response.data.filters.organism;
-
-    // also use this request to save the source revision returned in the headers
-    cache['sourceRevision'] = response.headers['x-source-revision'] || false;
   })
 ]).then(function() {
   fs.writeFileSync(`src/apiData.json`, JSON.stringify(cache));

--- a/src/common/errors.js
+++ b/src/common/errors.js
@@ -1,0 +1,14 @@
+/** Extending native classes can be tricky with babel
+ * https://stackoverflow.com/a/46971044/763705
+ */
+export class ExtendableError {
+  constructor(message) {
+    this.name = this.constructor.name;
+    this.message = message;
+    this.stack = new Error(message).stack;
+  }
+}
+ExtendableError.prototype = Object.create(Error.prototype);
+ExtendableError.prototype.constructor = ExtendableError;
+
+export class ApiVersionMismatchError extends ExtendableError {}

--- a/src/common/errors.js
+++ b/src/common/errors.js
@@ -1,14 +1,17 @@
 /** Extending native classes can be tricky with babel
  * https://stackoverflow.com/a/46971044/763705
  */
-export class ExtendableError {
+export class ExtendableError extends Error {
   constructor(message) {
+    super(message);
+    Object.setPrototypeOf(this, ExtendableError.prototype);
     this.name = this.constructor.name;
-    this.message = message;
-    this.stack = new Error(message).stack;
   }
 }
-ExtendableError.prototype = Object.create(Error.prototype);
-ExtendableError.prototype.constructor = ExtendableError;
 
-export class ApiVersionMismatchError extends ExtendableError {}
+export class ApiVersionMismatchError extends ExtendableError {
+  constructor(message) {
+    super(message);
+    Object.setPrototypeOf(this, ApiVersionMismatchError.prototype);
+  }
+}

--- a/src/common/helpers.js
+++ b/src/common/helpers.js
@@ -91,9 +91,15 @@ export async function asyncFetch(url, params = false) {
   }
 
   // check backend version to ensure it hasn't changed since the last deploy
-  const sourceRevision = response.headers.get('x-source-revision');
-  if (!!apiData.sourceRevision && apiData.sourceRevision !== sourceRevision) {
-    throw new ApiVersionMismatchError();
+  if (response.headers) {
+    const sourceRevision = response.headers.get('x-source-revision');
+    if (
+      !!sourceRevision &&
+      !!apiData.sourceRevision &&
+      apiData.sourceRevision !== sourceRevision
+    ) {
+      throw new ApiVersionMismatchError();
+    }
   }
 
   /**

--- a/src/common/helpers.js
+++ b/src/common/helpers.js
@@ -70,6 +70,10 @@ export function getRange(n) {
   return result;
 }
 
+// Store the last api version detected, this is used to detect updates to the api
+// while the app is running.
+let ApiSourceRevision = false;
+
 /**
  * Using fetch with async await that returns fulfilled value of the request
  *
@@ -77,7 +81,6 @@ export function getRange(n) {
  * @param {object} params
  * @returns {Promise}
  */
-
 export async function asyncFetch(url, params = false) {
   const fullURL = process.env.REACT_APP_API_HOST
     ? `${process.env.REACT_APP_API_HOST}${url}`
@@ -95,11 +98,14 @@ export async function asyncFetch(url, params = false) {
     const sourceRevision = response.headers.get('x-source-revision');
     if (
       !!sourceRevision &&
-      !!apiData.sourceRevision &&
-      apiData.sourceRevision !== sourceRevision
+      !!ApiSourceRevision &&
+      ApiSourceRevision !== sourceRevision
     ) {
       throw new ApiVersionMismatchError();
     }
+
+    // save the last source revision
+    ApiSourceRevision = sourceRevision;
   }
 
   /**

--- a/src/common/helpers.js
+++ b/src/common/helpers.js
@@ -1,5 +1,4 @@
 import SampleFieldMetadata from '../containers/Experiment/SampleFieldMetadata';
-import apiData from '../apiData.json';
 import { ApiVersionMismatchError } from '../common/errors';
 
 /**

--- a/src/common/helpers.js
+++ b/src/common/helpers.js
@@ -1,4 +1,6 @@
 import SampleFieldMetadata from '../containers/Experiment/SampleFieldMetadata';
+import apiData from '../apiData.json';
+import { ApiVersionMismatchError } from '../common/errors';
 
 /**
  * Generates a query string from a query object
@@ -85,7 +87,13 @@ export async function asyncFetch(url, params = false) {
   try {
     response = await (!!params ? fetch(fullURL, params) : fetch(fullURL));
   } catch (e) {
-    throw new Error(`Fatal error fetching ${url}`);
+    throw new Error(`Network error when fetching ${url}`);
+  }
+
+  // check backend version to ensure it hasn't changed since the last deploy
+  const sourceRevision = response.headers.get('x-source-revision');
+  if (!!apiData.sourceRevision && apiData.sourceRevision !== sourceRevision) {
+    throw new ApiVersionMismatchError();
   }
 
   /**

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -7,6 +7,7 @@ import { CALL_HISTORY_METHOD } from '../state/routerActions';
 import { REPORT_ERROR } from '../state/reportError';
 import throttle from 'lodash/throttle';
 import progressMiddleware from './progressMiddleware';
+import { ApiVersionMismatchError } from '../common/errors';
 
 declare var Raven: any;
 
@@ -18,6 +19,11 @@ const errorMiddleware = () => next => action => {
   }
 
   let error = action.data;
+
+  if (error instanceof ApiVersionMismatchError) {
+    // refresh the current page when the version of the api changes
+    window.location.reload();
+  }
 
   if (process.env.NODE_ENV === 'development') {
     // log exception in console on development


### PR DESCRIPTION
## Issue Number

close #149 
Needs https://github.com/AlexsLemonade/refinebio/issues/892

## Purpose/Implementation Notes

With https://github.com/AlexsLemonade/refinebio/pull/870, the version of the api will be sent on every request. 

Every time the frontend is deployed it will query the API and save it's version at that moment, then it will continue to check that the versions match on every network request. When they don't a page refresh will be triggered.

## Types of changes

* [x] New feature (non-breaking change which adds functionality)

## Functional tests

Checked with a local version of the api, updating the versions on both ends several times.

## Checklist

_Put an `x` in the boxes that apply._

* [x] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
* [ ] Any dependent changes have been merged and published in downstream modules
