### PR TITLE
Pass organisms to the experiments page

### DIFF
--- a/src/containers/Results/Result/index.js
+++ b/src/containers/Results/Result/index.js
@@ -42,6 +42,7 @@ const Result = ({ result, query }) => {
                 publication_authors: result.publication_authors,
                 source_url: result.source_url,
                 source_database: result.source_database,
+                organisms: result.organisms,
                 samples: []
               }
             })}
@@ -132,6 +133,7 @@ const Result = ({ result, query }) => {
               publication_authors: result.publication_authors,
               source_url: result.source_url,
               source_database: result.source_database,
+              organisms: result.organisms,
               samples: []
             }
           })}


### PR DESCRIPTION
Merging https://github.com/AlexsLemonade/refinebio-frontend/pull/451 and https://github.com/AlexsLemonade/refinebio-frontend/pull/433 caused a bug when navigating to the experiments page from the search, this fixes it.