### PR TITLE
Send experiment accession code when fetching sample details

### DIFF
--- a/src/api/samples.js
+++ b/src/api/samples.js
@@ -15,26 +15,14 @@ export async function getDetailedSample(sampleId) {
  * @param {number} offset
  * @param {number} limit
  */
-export async function getAllDetailedSamples({
-  accessionCodes,
-  orderBy,
-  offset,
-  limit,
-  filterBy
-}) {
-  if (accessionCodes && accessionCodes.length) {
-    let { count, results } = await Ajax.get('/samples/', {
-      // send the accession codes as a string, otherwise they will be converted to an array parameter
-      accession_codes: accessionCodes.join(','),
-      offset,
-      limit,
-      order_by: orderBy,
-      filter_by: filterBy || undefined // don't send the parameter  if `filterBy === ''`
-    });
-    return { count, data: results };
-  } else {
-    return [];
-  }
+export async function getAllDetailedSamples({ orderBy, filterBy, ...params }) {
+  let { count, results } = await Ajax.get('/samples/', {
+    ...params,
+    // send the accession codes as a string, otherwise they will be converted to an array parameter
+    order_by: orderBy,
+    filter_by: filterBy || undefined // don't send the parameter  if `filterBy === ''`
+  });
+  return { count, data: results };
 }
 
 export async function getGenomeBuild(organism) {

--- a/src/containers/Downloads/DownloadDetails.js
+++ b/src/containers/Downloads/DownloadDetails.js
@@ -29,6 +29,7 @@ import {
 } from '../../state/download/actions';
 
 import uniq from 'lodash/uniq';
+import union from 'lodash/union';
 import mapValues from 'lodash/mapValues';
 import groupBy from 'lodash/groupBy';
 
@@ -374,7 +375,12 @@ class ViewSamplesButtonModal extends React.Component {
       >
         {() => (
           <SamplesTable
-            dataSet={this.state.dataSet}
+            experimentSampleAssociations={this.state.dataSet}
+            fetchSampleParams={{
+              accession_codes: uniq(
+                union(...Object.values(this.state.dataSet))
+              ).join(',')
+            }}
             isImmutable={this.props.isImmutable}
           />
         )}

--- a/src/containers/Experiment/SamplesTable.js
+++ b/src/containers/Experiment/SamplesTable.js
@@ -41,7 +41,7 @@ class SamplesTable extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    if (!isEqual(prevProps.dataSet, this.props.dataSet)) {
+    if (!isEqual(prevProps.fetchSampleParams, this.props.fetchSampleParams)) {
       this.fetchData({ setPage: 0 });
     }
   }
@@ -145,7 +145,6 @@ class SamplesTable extends React.Component {
   }
 
   fetchData = async ({ tableState = false, setPage = undefined } = {}) => {
-    const accessionCodes = this._getSampleAccessionCodes();
     let { page, pageSize } = this.state;
     // get the backend ready `order_by` param, based on the sort options from the table
     let orderBy = this._getSortParam(tableState);
@@ -159,22 +158,23 @@ class SamplesTable extends React.Component {
     let offset = page * pageSize;
 
     let { count, data } = await getAllDetailedSamples({
-      accessionCodes,
       orderBy,
       offset,
       limit: pageSize,
-      filterBy: this.state.filter
+      filterBy: this.state.filter,
+      ...(this.props.fetchSampleParams || {})
     });
 
     // add a new property to all samples, with the experiment accession codes that reference it in
     // the dataset slice. This is needed when adding/removing the sample from the dataset
     data = data.map(sample => ({
       ...sample,
-      experimentAccessionCodes: Object.keys(this.props.dataSet).filter(
-        experimentAccessionCode =>
-          this.props.dataSet[experimentAccessionCode].includes(
-            sample.accession_code
-          )
+      experimentAccessionCodes: Object.keys(
+        this.props.experimentSampleAssociations
+      ).filter(experimentAccessionCode =>
+        this.props.experimentSampleAssociations[
+          experimentAccessionCode
+        ].includes(sample.accession_code)
       )
     }));
 

--- a/src/containers/Experiment/index.js
+++ b/src/containers/Experiment/index.js
@@ -300,8 +300,7 @@ function ExperimentHelmet({ experiment }) {
 
 class ExperimentSamplesTable extends React.Component {
   state = {
-    showOnlyAddedSamples: false,
-    onlyAddedSamples: []
+    showOnlyAddedSamples: false
   };
 
   render() {
@@ -309,8 +308,16 @@ class ExperimentSamplesTable extends React.Component {
 
     return (
       <SamplesTable
-        dataSet={{
-          [experiment.accession_code]: this._getSamplesToBeDisplayed()
+        experimentSampleAssociations={{
+          [experiment.accession_code]: this.props.experiment.samples.map(
+            x => x.accession_code
+          )
+        }}
+        fetchSampleParams={{
+          experiment_accession_code: experiment.accession_code,
+          dataset_id: this.state.showOnlyAddedSamples
+            ? this.props.dataSetId
+            : undefined
         }}
         // Render prop for the button that adds the samples to the dataset
         pageActionComponent={samplesDisplayed => {
@@ -326,8 +333,7 @@ class ExperimentSamplesTable extends React.Component {
                   checked={this.state.showOnlyAddedSamples}
                   onChange={() =>
                     this.setState(state => ({
-                      showOnlyAddedSamples: !state.showOnlyAddedSamples,
-                      onlyAddedSamples: stats.getSamplesInDataSet()
+                      showOnlyAddedSamples: !state.showOnlyAddedSamples
                     }))
                   }
                   disabled={
@@ -357,16 +363,6 @@ class ExperimentSamplesTable extends React.Component {
     );
   }
 
-  _getSamplesToBeDisplayed() {
-    if (this.state.showOnlyAddedSamples) {
-      // show only the samples that are present in the dataset
-      return this.state.onlyAddedSamples;
-    }
-
-    // return the accession codes of all samples
-    return this.props.experiment.samples.map(x => x.accession_code);
-  }
-
   /**
    * Bulilds a dataset slice, that only contains the current experiment accession code
    * with it's processed samples
@@ -381,6 +377,7 @@ class ExperimentSamplesTable extends React.Component {
     };
   }
 }
-ExperimentSamplesTable = connect(({ download: { dataSet } }) => ({ dataSet }))(
-  ExperimentSamplesTable
-);
+ExperimentSamplesTable = connect(({ download: { dataSetId, dataSet } }) => ({
+  dataSetId,
+  dataSet
+}))(ExperimentSamplesTable);


### PR DESCRIPTION
## Issue Number

close #464 

## Purpose/Implementation Notes

Use parameter `experiment_accession_code` for the samples table in the experiments page.

The request will now be: https://api.refine.bio/samples/?offset=0&limit=10&experiment_accession_code=GSE31162

## Types of changes
* [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

Check samples table in experiments page and downloads page.

## Checklist

* [x] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
* [x] Any dependent changes have been merged and published in downstream modules

