### PR TITLE
Recover if getting stats fails

### DIFF
--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -21,14 +21,14 @@ branch=$(get_master_or_dev)
 
 if [[ $branch == "master" ]]; then
     base_host="refine.bio"
-    BUCKET_NAME=s3://www.$base_host
 elif [[ $branch == "dev" ]]; then
     base_host="staging.refine.bio"
-    BUCKET_NAME=s3://$base_host
 else
     echo "Why in the world was update_docker_img.sh called from a branch other than dev or master?!?!?"
     exit 1
 fi
+
+BUCKET_NAME=s3://$base_host
 
 yarn install --ignore-engines
 

--- a/src/components/Toggle/index.js
+++ b/src/components/Toggle/index.js
@@ -28,20 +28,23 @@ class Toggle extends Component {
     return (
       <div className={classnames('toggle', this.props.className)}>
         <ul className="toggle__container">
-          {tabs.map((tab, i) => (
-            <li key={i} className={`toggle__item`}>
-              <button
-                className={`toggle__button ${
-                  i === this.state.activeTabIndex
-                    ? 'toggle__button--active'
-                    : ''
-                }`}
-                onClick={() => this.handleToggle(i)}
-              >
-                {tab}
-              </button>
-            </li>
-          ))}
+          {tabs.map(
+            (tab, i) =>
+              !!tab && (
+                <li key={tab.toString()} className={`toggle__item`}>
+                  <button
+                    className={`toggle__button ${
+                      i === this.state.activeTabIndex
+                        ? 'toggle__button--active'
+                        : ''
+                    }`}
+                    onClick={() => this.handleToggle(i)}
+                  >
+                    {tab}
+                  </button>
+                </li>
+              )
+          )}
         </ul>
       </div>
     );

--- a/src/containers/Main/graphs.js
+++ b/src/containers/Main/graphs.js
@@ -25,7 +25,7 @@ function getSamplesPerSpecies() {
       samples: organism[name]
     }))
     .sort((x, y) => y.samples - x.samples)
-    .slice(0, 20);
+    .slice(0, 10);
 }
 
 let SamplesPerSpeciesGraph = ({ push }) => {
@@ -68,7 +68,15 @@ SamplesPerSpeciesGraph = connect(
 )(SamplesPerSpeciesGraph);
 export { SamplesPerSpeciesGraph };
 
-function getSamplesOverTime() {
+export function getSamplesOverTime() {
+  if (
+    !apiData.stats ||
+    !apiData.stats.samples ||
+    !apiData.stats.samples.timeline
+  ) {
+    return false;
+  }
+
   const { samples } = apiData.stats;
   return accumulateByKeys(samples.timeline, ['total']).filter(
     x => moment(x.start).isAfter('2018-07-01') // only show data after our launch
@@ -77,6 +85,7 @@ function getSamplesOverTime() {
 
 export function SamplesOverTimeGraph() {
   const data = getSamplesOverTime();
+  if (!data) return null;
   return (
     <div style={{ minHeight: 400 }}>
       <div style={{ height: 500 }}>

--- a/src/containers/Main/index.js
+++ b/src/containers/Main/index.js
@@ -9,8 +9,13 @@ import SearchIcon from '../../common/icons/search.svg';
 import DatasetIcon from '../../common/icons/dataset.svg';
 import ExploreIcon from '../../common/icons/explore.svg';
 import './Main.scss';
-import { SamplesPerSpeciesGraph, SamplesOverTimeGraph } from './graphs';
+import {
+  SamplesPerSpeciesGraph,
+  SamplesOverTimeGraph,
+  getSamplesOverTime
+} from './graphs';
 import TabControl from '../../components/TabControl';
+import apiData from '../../apiData.json';
 
 let Main = ({ searchTerm, fetchResults, push }) => {
   return (
@@ -112,19 +117,24 @@ let Main = ({ searchTerm, fetchResults, push }) => {
           </div>
         </div>
       </section>
-      <section className="main__section main__section--gray">
-        <div className="main__container">
-          <h2 className="main__heading-1">Summary Statistics</h2>
+      {(getSamplesOverTime() || apiData.organism) && (
+        <section className="main__section main__section--gray">
+          <div className="main__container">
+            <h2 className="main__heading-1">Summary Statistics</h2>
 
-          <TabControl
-            tabs={['Samples per Species', 'Samples over Time']}
-            toggleClassName="toggle--statics-tabs"
-          >
-            <SamplesPerSpeciesGraph />
-            <SamplesOverTimeGraph />
-          </TabControl>
-        </div>
-      </section>
+            <TabControl
+              tabs={[
+                apiData.organism ? 'Samples per Species' : false,
+                getSamplesOverTime() ? 'Samples over Time' : false
+              ]}
+              toggleClassName="toggle--statics-tabs"
+            >
+              <SamplesPerSpeciesGraph />
+              <SamplesOverTimeGraph />
+            </TabControl>
+          </div>
+        </section>
+      )}
       <section className="main__section main__section--blue-gradient">
         <div className="main__container">
           <div className="main__heading-1">Sign Up for Updates</div>

--- a/src/containers/Main/index.js
+++ b/src/containers/Main/index.js
@@ -36,7 +36,8 @@ let Main = ({ searchTerm, fetchResults, push }) => {
           />
           <div className="main__search-suggestions">
             <p className="main__search-suggestion-label">Try searching for:</p>
-            {['Notch', 'Medulloblastoma', 'GSE16476', 'Versteeg'].map(q => (
+
+            {['Notch', 'Medulloblastoma', 'GSE24528'].map(q => (
               <Link
                 className="main__search-suggestion"
                 to={`/results?q=${q}`}

--- a/src/containers/Results/index.js
+++ b/src/containers/Results/index.js
@@ -268,7 +268,7 @@ const NoSearchResults = () => (
     <h2>No matching results</h2>
     <h2>Try another term</h2>
     <div className="results__suggestions">
-      {['Notch', 'Medulloblastoma', 'GSE16476', 'Versteeg'].map(q => (
+      {['Notch', 'Medulloblastoma', 'GSE24528'].map(q => (
         <Link
           className="link results__suggestion"
           to={`/results?q=${q}`}


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio/issues/938

## Purpose/Implementation Notes

The stats in the landing page weren't being updated, the `/stats` endpoint call was failing and the script wasn't updating the cache file.

This handles any error that might occur, and hides the samples over time graph. Until we're able to get it from `/stats`

## Types of changes

* [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

Run `yarn run cacheBackend` and ensure the graphs in the landing page are updated.

## Checklist

* [x] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
* [x] Any dependent changes have been merged and published in downstream modules

## Screenshots

![image](https://user-images.githubusercontent.com/1882507/50109505-02b53480-0206-11e9-8f09-2c5b1846d2c6.png)
