### PR TITLE
add delayed-scroll-restoration-polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@haiku/dvprasad-processingdataset": "^0.0.1",
     "@haiku/dvprasad-refinebiospinner": "^0.0.4",
     "custom-react-scripts": "^0.2.2",
+    "delayed-scroll-restoration-polyfill": "^0.1.1",
     "history": "^4.7.2",
     "husky": "^0.14.3",
     "lint-staged": "^7.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,8 @@ import { unregister } from './registerServiceWorker';
 
 import smoothscroll from 'smoothscroll-polyfill';
 
+import 'delayed-scroll-restoration-polyfill';
+
 // kick off the polyfill!
 smoothscroll.polyfill();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2512,6 +2512,10 @@ del@^3.0.0:
     pify "^3.0.0"
     rimraf "^2.2.8"
 
+delayed-scroll-restoration-polyfill@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/delayed-scroll-restoration-polyfill/-/delayed-scroll-restoration-polyfill-0.1.1.tgz#f770175da3f8e565fea993162b4c539e701f7a0f"
+
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"


### PR DESCRIPTION
## Issue Number

close #393 

## Purpose/Implementation Notes

Found [a polyfill](https://github.com/brigade/delayed-scroll-restoration-polyfill) that takes care of restoring scroll position in FF, mimicking chrome. @Miserlou 

## Types of changes

* [x] Bugfix (non-breaking change which fixes an issue)

## Functional tests

Test search, navigating to experiments and then going back

## Checklist

* [x] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
* [x] Any dependent changes have been merged and published in downstream modules

## Screenshots

![2018-12-20 15 28 01](https://user-images.githubusercontent.com/1882507/50309185-e31f4580-046b-11e9-8a87-ddb79d79a911.gif)
