### PR TITLE
Remove download estimates

### DIFF
--- a/src/common/helpers.js
+++ b/src/common/helpers.js
@@ -279,7 +279,7 @@ export function accumulateByKeys(array, keys) {
 
 // thanks to https://stackoverflow.com/a/18650828/763705
 export function formatBytes(bytes, decimals = 2) {
-  if (bytes == 0) return '0 Bytes';
+  if (bytes === 0) return '0 Bytes';
   const k = 1024;
   const dm = decimals <= 0 ? 0 : decimals;
   const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];

--- a/src/common/helpers.js
+++ b/src/common/helpers.js
@@ -276,3 +276,14 @@ export function accumulateByKeys(array, keys) {
     }, {})
   }));
 }
+
+// thanks to https://stackoverflow.com/a/18650828/763705
+export function formatBytes(bytes, decimals = 2) {
+  if (bytes == 0) return '0 Bytes';
+  const k = 1024;
+  const dm = decimals <= 0 ? 0 : decimals;
+  const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+
+  return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i];
+}

--- a/src/containers/Downloads/DataSet/index.js
+++ b/src/containers/Downloads/DataSet/index.js
@@ -149,8 +149,6 @@ function DataSetPageHeader({ dataSetId, email_address, hasError, dataSet }) {
     is_processing,
     is_available,
     expires_on,
-    s3_bucket,
-    s3_key,
     success
   } = dataSet;
 

--- a/src/containers/Downloads/DataSet/index.js
+++ b/src/containers/Downloads/DataSet/index.js
@@ -1,7 +1,11 @@
 import React from 'react';
 import Helmet from 'react-helmet';
 import moment from 'moment';
-import { getAmazonDownloadLinkUrl, timeout } from '../../../common/helpers';
+import {
+  getAmazonDownloadLinkUrl,
+  timeout,
+  formatBytes
+} from '../../../common/helpers';
 import Loader from '../../../components/Loader';
 import DownloadImage from './download-dataset.svg';
 import DownloadExpiredImage from './download-expired-dataset.svg';
@@ -158,7 +162,7 @@ function DataSetPageHeader({ dataSetId, email_address, hasError, dataSet }) {
     <DataSetErrorDownloading dataSetId={dataSetId} dataSet={dataSet} />
   ) : is_processed ? (
     is_available && !isExpired ? (
-      <DataSetReady s3_bucket={s3_bucket} s3_key={s3_key} />
+      <DataSetReady dataSet={dataSet} />
     ) : (
       <DataSetExpired />
     )
@@ -284,7 +288,7 @@ class DataSetReady extends React.Component {
       await this.props.createToken();
     }
 
-    const { s3_bucket, s3_key } = this.props;
+    const { s3_bucket, s3_key } = this.props.dataSet;
     const downloadLink = getAmazonDownloadLinkUrl(s3_bucket, s3_key);
     window.location.href = downloadLink;
   };
@@ -296,6 +300,13 @@ class DataSetReady extends React.Component {
           <div className="dataset__way-container">
             <div className="dataset__processed-text">
               <h1>Your dataset is ready for download!</h1>
+
+              {!!this.props.dataSet.size_in_bytes && (
+                <div className="mb-1">
+                  Download size: {formatBytes(this.props.dataSet.size_in_bytes)}
+                </div>
+              )}
+
               <div className="dataset__way-container">
                 {!this.props.hasToken && (
                   <TermsOfUse
@@ -303,6 +314,7 @@ class DataSetReady extends React.Component {
                     handleToggle={this.handleAgreedToTerms}
                   />
                 )}
+
                 <Button
                   onClick={this.handleSubmit}
                   isDisabled={!this.state.agreedToTerms && !this.props.hasToken}

--- a/src/containers/Downloads/DownloadFileSummary.js
+++ b/src/containers/Downloads/DownloadFileSummary.js
@@ -42,16 +42,10 @@ const DownloadFileSummary = ({
             <h4>{card.title}</h4>
             <p>{card.description}</p>
             <div className="downloads__card-stats">
-              <p className="downloads__card-stat">Total Size: {card.size}</p>
               <p className="downloads__card-stat">Format: {card.format}</p>
             </div>
           </div>
         ))}
-
-        <div className="downloads__card">
-          <h4>Estimated Download Size</h4>
-          <h4>{summaryData.total}</h4>
-        </div>
       </div>
     </section>
   );

--- a/src/containers/Downloads/DownloadFileSummary.js
+++ b/src/containers/Downloads/DownloadFileSummary.js
@@ -40,9 +40,9 @@ const DownloadFileSummary = ({
         {summaryData.files.map((card, i) => (
           <div className="downloads__card" key={i}>
             <h4>{card.title}</h4>
-            <p>{card.description}</p>
             <div className="downloads__card-stats">
-              <p className="downloads__card-stat">Format: {card.format}</p>
+              <div className="downloads__card-stat">{card.description}</div>
+              <div className="downloads__card-stat">Format: {card.format}</div>
             </div>
           </div>
         ))}

--- a/src/containers/Downloads/Downloads.scss
+++ b/src/containers/Downloads/Downloads.scss
@@ -75,7 +75,7 @@
     box-shadow: 0 3px 20px 0 rgba($black, 0.1);
     flex: 1;
     margin: 1rem 0;
-    padding: 18px 0;
+    padding: 16px 24px;
     text-align: center;
 
     display: flex;
@@ -91,12 +91,11 @@
   &__card-stats {
     align-items: center;
     display: flex;
-    justify-content: center;
+    justify-content: space-between;
   }
 
   &__card-stat {
-    font-size: 0.875rem;
-    margin: 0 0.5rem;
+    font-size: 1rem;
   }
 
   &__table {

--- a/src/containers/Downloads/Downloads.scss
+++ b/src/containers/Downloads/Downloads.scss
@@ -56,12 +56,10 @@
   }
 
   &__cards {
-    padding: 0 7px;
-
     @include tablet {
       display: grid;
       grid-column-gap: 14px;
-      grid-template-columns: repeat(4, 1fr);
+      grid-template-columns: repeat(3, 1fr);
     }
   }
 

--- a/src/containers/Downloads/downloadFilesData.js
+++ b/src/containers/Downloads/downloadFilesData.js
@@ -4,37 +4,22 @@
 export function downloadsFilesDataBySpecies(dataSet, samplesBySpecies) {
   const totalExperiments = Object.keys(dataSet).length;
   const totalSpecies = Object.keys(samplesBySpecies).length;
-  const geneExpressionSize = estimateGeneExpressionSize(samplesBySpecies);
-  const sampleMetadataSize = estimateSampleMetadataSize(dataSet);
-  const qualityReportSize = estimateSpecieMetadataSize(dataSet);
-
-  const allMetadataFileSize = sampleMetadataSize + qualityReportSize;
-
-  const totalSize =
-    geneExpressionSize +
-    sampleMetadataSize +
-    qualityReportSize +
-    allMetadataFileSize;
 
   const data = {
-    total: formatBytes(totalSize),
     files: [
       {
         title: `${totalSpecies} Gene Expression Matrices`,
         description: '1 file per Species',
-        size: formatBytes(geneExpressionSize),
         format: 'tsv'
       },
       {
         title: `${totalExperiments} Sample Metadata Files`,
         description: '1 file per Experiment',
-        size: formatBytes(sampleMetadataSize),
         format: 'tsv'
       },
       {
         title: `${totalSpecies} Species Metadata`,
         description: '1 file per Species',
-        size: formatBytes(qualityReportSize),
         format: 'json'
       }
     ]
@@ -49,108 +34,26 @@ export function downloadsFilesDataBySpecies(dataSet, samplesBySpecies) {
  */
 export function downloadsFilesDataByExperiment(dataSet) {
   const totalExperiments = Object.keys(dataSet).length;
-  const geneExpressionSize = estimateGeneExpressionSize(dataSet);
-  const sampleMetadataSize = estimateSampleMetadataSize(dataSet);
-  const qualityReportSize = estimateExperimentMetadataSize(dataSet);
-
-  const allMetadataFileSize = sampleMetadataSize + qualityReportSize;
-
-  const totalSize =
-    geneExpressionSize +
-    sampleMetadataSize +
-    qualityReportSize +
-    allMetadataFileSize;
 
   const data = {
-    total: formatBytes(totalSize),
     files: [
       {
         title: `${totalExperiments} Gene Expression Matrices`,
         description: '1 file per Experiment',
-        size: formatBytes(geneExpressionSize),
         format: 'tsv'
       },
       {
         title: `${totalExperiments} Sample Metadata Files`,
         description: '1 file per Experiment',
-        size: formatBytes(sampleMetadataSize),
         format: 'tsv'
       },
       {
         title: `${totalExperiments} Experiment Metadata Files`,
         description: '1 file per Experiment',
-        size: formatBytes(qualityReportSize),
         format: 'json'
       }
     ]
   };
 
   return data;
-}
-
-// TODO add a better estimation of the size of each sample metadata
-function sampleMetadata() {
-  const SAMPLE_SIZE = 5 * 1024;
-  return SAMPLE_SIZE;
-}
-
-// TODO add correct estimate for the matrix of a sample
-function estimateMatrixSizeOfSample() {
-  return 20 * 256;
-}
-
-/**
- * Estimate the gene experssion matrix file sizes for a given dataset, this code was written using
- * https://github.com/AlexsLemonade/refinebio-frontend/issues/25#issue-324513980
- * as a guidance.
- */
-function estimateGeneExpressionSize(dataSet) {
-  let totalSize = 0;
-
-  // calculate the size of each one of the experiments
-  for (let experimentId of Object.keys(dataSet)) {
-    let experimentSamples = dataSet[experimentId];
-    // Need size of gene column for the first matrix.
-    let experimentSize =
-      (experimentSamples.length + 1) * 0.5 * estimateMatrixSizeOfSample();
-    totalSize = totalSize + experimentSize;
-  }
-
-  return totalSize;
-}
-
-function estimateSampleMetadataSize(dataSet) {
-  let result = 0;
-  // Count the total number of samples, and multiply it with the average sample size
-  for (let experimentId of Object.keys(dataSet)) {
-    let experimentSamples = dataSet[experimentId];
-    result = result + sampleMetadata() * Object.keys(experimentSamples).length;
-  }
-  return result;
-}
-
-function estimateExperimentMetadataSize(dataSet) {
-  // TODO Estimated size of experiment metadata file
-  const EXPERIMENT_SIZE = 4048;
-  return Object.keys(dataSet).length * EXPERIMENT_SIZE;
-}
-
-function estimateSpecieMetadataSize(samplesBySpecies) {
-  const SAMPLE_SIZE = 2048;
-  return Object.keys(samplesBySpecies).length * SAMPLE_SIZE;
-}
-
-/**
- * String formatting of file size
- * thanks to https://stackoverflow.com/a/18650828/763705
- * @param {*} bytes
- * @param {*} decimals
- */
-function formatBytes(bytes, decimals = 2) {
-  if (bytes === 0) return '0 Bytes';
-  let k = 1024,
-    dm = decimals,
-    sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'],
-    i = Math.floor(Math.log(bytes) / Math.log(k));
-  return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i];
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -121,6 +121,10 @@ fieldset {
   }
 }
 
+.mb-1 {
+  margin-bottom: 1rem;
+}
+
 .mr-1 {
   margin-right: 1rem;
 }


### PR DESCRIPTION
## Issue Number

close #470 

## Purpose/Implementation Notes

Removes all download size estimates and uses the actual dataset size next to the download link, included with https://github.com/AlexsLemonade/refinebio/pull/979

@dvenprasad do you think the Download File Summary looks good like this?

## Types of changes

* [x] New feature (non-breaking change which adds functionality)

## Functional tests

Download a dataset

## Checklist

* [x] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
* [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

![image](https://user-images.githubusercontent.com/1882507/51059338-d6e55e80-15b9-11e9-951a-6e5016c38e9c.png)