### PR TITLE
Updates to frontend after api optimizations

### DIFF
--- a/src/containers/Experiment/DataSetStats.js
+++ b/src/containers/Experiment/DataSetStats.js
@@ -96,7 +96,9 @@ export default class DataSetStats {
    */
   anyProcessedSamples() {
     return Object.values(this.dataSetSlice).some(
-      samples => samples && samples.length > 0
+      samples =>
+        (samples && samples.length > 0) ||
+        (samples && samples.all && samples.total > 0)
     );
   }
 

--- a/src/containers/Experiment/DataSetStats.js
+++ b/src/containers/Experiment/DataSetStats.js
@@ -19,10 +19,16 @@ export class DataSetOperations {
       Object.keys(d2)
     );
     for (let experimentAccession of addedExperimentAccession) {
-      result[experimentAccession] = intersect(
-        d1[experimentAccession],
-        d2[experimentAccession]
-      );
+      if (d2[experimentAccession].all) {
+        result[experimentAccession] = d1[experimentAccession];
+      } else if (d1[experimentAccession].all) {
+        result[experimentAccession] = d2[experimentAccession];
+      } else {
+        result[experimentAccession] = intersect(
+          d1[experimentAccession],
+          d2[experimentAccession]
+        );
+      }
     }
     return result;
   }
@@ -47,6 +53,20 @@ export class DataSetOperations {
     }
 
     for (let accession of d1Keys) {
+      if (d1[accession].all) {
+        if (d1[accession].total !== d2[accession].length) {
+          return false;
+        } else {
+          continue;
+        }
+      }
+      if (d2[accession].all) {
+        if (d2[accession].total !== d1[accession].length) {
+          return false;
+        } else {
+          continue;
+        }
+      }
       if (!DataSetOperations._sameItems(d1[accession], d2[accession])) {
         return false;
       }

--- a/src/containers/Experiment/DataSetStats.test.js
+++ b/src/containers/Experiment/DataSetStats.test.js
@@ -50,6 +50,13 @@ describe('DataSetOperations', () => {
     expect(DataSetOperations.intersect(d1, d2)).toEqual({ e1: ['s1'] });
   });
 
+  it('intersect with all accessions from experiment', () => {
+    const d1 = { e1: ['s1'], e2: ['s2'] };
+    const d2 = { e1: { all: true, total: 10 } };
+    expect(DataSetOperations.intersect(d1, d2)).toEqual({ e1: ['s1'] });
+    expect(DataSetOperations.intersect(d2, d1)).toEqual({ e1: ['s1'] });
+  });
+
   it('isEqual to empty dataset', () => {
     const d1 = {};
     const d2 = { e1: ['s1', 's2'] };
@@ -60,5 +67,17 @@ describe('DataSetOperations', () => {
     const d1 = { e1: ['s2', 's1'], e2: ['s3'] };
     const d2 = { e2: ['s3'], e1: ['s1', 's2'] };
     expect(DataSetOperations.equal(d1, d2)).toBeTruthy();
+  });
+
+  it('equal comparing all codes with the same total', () => {
+    const d1 = { e1: ['s1', 's2'] };
+    const d2 = { e1: { all: true, total: 2 } }; // more accession codes than the ones in d1
+    expect(DataSetOperations.equal(d1, d2)).toBeTruthy();
+  });
+
+  it('equal comparing all experiment accession codes mismatch', () => {
+    const d1 = { e1: ['s1'] };
+    const d2 = { e1: { all: true, total: 2 } }; // more accession codes than the ones in d1
+    expect(DataSetOperations.equal(d1, d2)).toBeFalsy();
   });
 });

--- a/src/containers/Experiment/index.js
+++ b/src/containers/Experiment/index.js
@@ -62,7 +62,7 @@ let Experiment = ({
               samples: []
             };
             totalSamples = state.result.total_samples_count;
-            organisms = state.result.organisms.map(name => ({ name }));
+            organisms = state.result.organism_names;
           }
 
           return displaySpinner ? (

--- a/src/containers/Results/Result/index.js
+++ b/src/containers/Results/Result/index.js
@@ -42,7 +42,7 @@ const Result = ({ result, query }) => {
                 publication_authors: result.publication_authors,
                 source_url: result.source_url,
                 source_database: result.source_database,
-                organisms: result.organisms,
+                organism_names: result.organism_names,
                 samples: []
               }
             })}
@@ -134,7 +134,7 @@ const Result = ({ result, query }) => {
               publication_authors: result.publication_authors,
               source_url: result.source_url,
               source_database: result.source_database,
-              organisms: result.organisms,
+              organism_names: result.organism_names,
               samples: []
             }
           })}

--- a/src/containers/Results/Result/index.js
+++ b/src/containers/Results/Result/index.js
@@ -57,7 +57,10 @@ const Result = ({ result, query }) => {
 
         <DataSetSampleActions
           dataSetSlice={{
-            [result.accession_code]: result.processed_samples
+            [result.accession_code]: {
+              all: true,
+              total: result.processed_samples
+            }
           }}
         />
       </div>
@@ -68,26 +71,24 @@ const Result = ({ result, query }) => {
             className="result__icon"
             alt="organism-icon"
           />{' '}
-          {result.organisms
-            .map(organism => formatSentenceCase(organism))
-            .join(', ') || 'No species.'}
+          {(result.organism_names &&
+            result.organism_names
+              .map(organism => formatSentenceCase(organism))
+              .join(', ')) ||
+            'No species.'}
         </li>
         <li className="result__stat">
           <img src={SampleIcon} className="result__icon" alt="sample-icon" />{' '}
-          {result.total_samples_count} Sample{result.total_samples_count > 1 &&
-            's'}
+          {result.num_processed_samples} Sample{result.num_processed_samples >
+            1 && 's'}
         </li>
         <li className="result__stat">
           <TechnologyBadge
             className="result__icon"
-            isMicroarray={
-              result.technologies && result.technologies.includes(MICROARRAY)
-            }
-            isRnaSeq={
-              result.technologies && result.technologies.includes(RNA_SEQ)
-            }
+            isMicroarray={result.technology === MICROARRAY}
+            isRnaSeq={result.technology === RNA_SEQ}
           />
-          {result.pretty_platforms.filter(platform => !!platform).join(', ')}
+          {result.platform_names.filter(platform => !!platform).join(', ')}
         </li>
       </ul>
 

--- a/src/containers/Results/Result/index.js
+++ b/src/containers/Results/Result/index.js
@@ -59,7 +59,7 @@ const Result = ({ result, query }) => {
           dataSetSlice={{
             [result.accession_code]: {
               all: true,
-              total: result.processed_samples
+              total: result.num_processed_samples
             }
           }}
         />

--- a/src/containers/Results/ResultFilters/FilterCategory.js
+++ b/src/containers/Results/ResultFilters/FilterCategory.js
@@ -60,13 +60,13 @@ class FilterCategory extends React.Component {
                   onChange={() =>
                     toggledFilter(
                       category.queryField,
-                      filter === 'has_publication' ? 'True' : filter
+                      filter === 'has_publication' ? 'true' : filter
                     )
                   }
                   checked={
                     !!appliedFilters[category.queryField] &&
                     appliedFilters[category.queryField].includes(
-                      filter === 'has_publication' ? 'True' : filter
+                      filter === 'has_publication' ? 'true' : filter
                     )
                   }
                 >

--- a/src/containers/Results/ResultFilters/index.js
+++ b/src/containers/Results/ResultFilters/index.js
@@ -65,9 +65,10 @@ let Filters = ({ appliedFilters }) => (
 export default Filters;
 
 const filterCategories = [
-  { name: 'organism', queryField: 'organisms__name' },
+  { name: 'organism', queryField: 'organism' },
   { name: 'technology', queryField: 'technology' },
-  { name: 'publication', queryField: 'has_publication' }
+  { name: 'publication', queryField: 'has_publication' },
+  { name: 'platforms', queryField: 'platform' }
 ];
 
 /**

--- a/src/containers/Results/index.js
+++ b/src/containers/Results/index.js
@@ -212,7 +212,10 @@ export default Results;
 function AddPageToDataSetButton({ results }) {
   // create a dataset slice with the results, use the accession codes in `processed_samples`
   const resultsDataSetSlice = fromPairs(
-    results.map(result => [result.accession_code, result.processed_samples])
+    results.map(result => [
+      result.accession_code,
+      { all: true, total: result.num_processed_samples }
+    ])
   );
 
   return (

--- a/src/state/download/DataSetManager.js
+++ b/src/state/download/DataSetManager.js
@@ -24,10 +24,16 @@ export default class DataSetManager {
   add(dataSetSlice) {
     let result = { ...this.dataSet };
     for (let accessionCode of Object.keys(dataSetSlice)) {
-      result[accessionCode] = uniq([
-        ...(result[accessionCode] || []),
-        ...dataSetSlice[accessionCode]
-      ]);
+      if (dataSetSlice[accessionCode].all) {
+        // special code to add all samples from an experiment
+        // https://github.com/AlexsLemonade/refinebio-frontend/issues/496#issuecomment-456543865
+        result[accessionCode] = ['ALL'];
+      } else {
+        result[accessionCode] = uniq([
+          ...(result[accessionCode] || []),
+          ...dataSetSlice[accessionCode]
+        ]);
+      }
     }
     return result;
   }

--- a/src/state/search/actions.js
+++ b/src/state/search/actions.js
@@ -55,7 +55,7 @@ export function fetchResults({
         results,
         count: totalResults,
         filters: filterData
-      } = await Ajax.get('/search/', {
+      } = await Ajax.get('/es/', {
         ...(query ? { search: query } : {}),
         limit: size,
         offset: (page - 1) * size,
@@ -72,7 +72,7 @@ export function fetchResults({
         data: {
           searchTerm: query,
           results,
-          filters: filterData,
+          filters: {}, // filterData,
           filterOrder,
           totalResults,
           ordering,

--- a/src/state/search/reducer.js
+++ b/src/state/search/reducer.js
@@ -1,7 +1,7 @@
 const initialState = {
   searchTerm: '',
   results: [],
-  filters: {},
+  filters: null,
   filterOrder: [],
   appliedFilters: {},
   pagination: {


### PR DESCRIPTION
## Issue Number

close #496 

## Purpose/Implementation Notes

Makes the search page work with the changes introduced in https://github.com/AlexsLemonade/refinebio/pull/974

The logic for the interactive filters was removed from the API and moved into the frontend. When the user visits the search page, a second api query will be done to fetch the filters stats without the last filter applied. This will only be done on the initial page load, otherwise the app will build the filters with a single query.

*Integration for the search are timing out because we're querying refine.bio* I'll change it to use staging once that api is restored.

## Types of changes

* [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

Search

## Checklist

* [x] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
* [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

![2019-01-23 15 18 25](https://user-images.githubusercontent.com/1882507/51634411-2d3f8f00-1f22-11e9-8fe8-9654d01976e4.gif)
