### PR TITLE
Separate create and edit api calls when regenerating dataset

### DIFF
--- a/src/api/dataSet.js
+++ b/src/api/dataSet.js
@@ -13,6 +13,13 @@ export async function getDataSetDetails(dataSetId) {
   };
 }
 
+/**
+ * Creates a new dataset
+ */
+export async function createDataSet() {
+  return await Ajax.post('/dataset/create/', { data: {} });
+}
+
 export async function updateDataSet(dataSetId, dataSet, details = false) {
   // It's not technically wrong to add a query parameter to the URL of a PUT request. ref https://github.com/AlexsLemonade/refinebio-frontend/pull/485#discussion_r246158557
   // In this case, after a dataset is modified we'll need to fetch detailed information for it,

--- a/src/state/dataSet/actions.js
+++ b/src/state/dataSet/actions.js
@@ -4,7 +4,6 @@ import { replace, push } from '../../state/routerActions';
 import {
   getDataSet,
   getDataSetDetails,
-  updateDataSet as updateDataSetApi,
   createDataSet
 } from '../../api/dataSet';
 

--- a/src/state/dataSet/actions.js
+++ b/src/state/dataSet/actions.js
@@ -1,7 +1,12 @@
 import { Ajax } from '../../common/helpers';
 import reportError from '../reportError';
 import { replace, push } from '../../state/routerActions';
-import { getDataSet, getDataSetDetails } from '../../api/dataSet';
+import {
+  getDataSet,
+  getDataSetDetails,
+  updateDataSet as updateDataSetApi,
+  createDataSet
+} from '../../api/dataSet';
 
 export const loadDataSet = dataSet => ({
   type: 'LOAD_DATASET',
@@ -46,14 +51,16 @@ export const regenerateDataSet = () => async (dispatch, getState) => {
   let { data, aggregate_by, scale_by } = getState().dataSet;
 
   try {
-    // create a new dataset
-    let { id: dataSetId } = await Ajax.post('/dataset/create/', {
+    // 1. create a new dataset
+    let { id: dataSetId } = await createDataSet();
+    // 2. add the same data
+    await Ajax.put(`/dataset/${dataSetId}/`, {
       data,
       aggregate_by,
       scale_by
     });
 
-    // redirect to the new dataset page, where the user will be able to add an email
+    // 3. redirect to the new dataset page, where the user will be able to add an email
     dispatch(
       push({
         pathname: `/dataset/${dataSetId}`,

--- a/src/state/download/actions.js
+++ b/src/state/download/actions.js
@@ -2,7 +2,8 @@ import { Ajax } from '../../common/helpers';
 import {
   getDataSet,
   getDataSetDetails,
-  updateDataSet
+  updateDataSet,
+  createDataSet
 } from '../../api/dataSet';
 import reportError from '../reportError';
 import DataSetManager from './DataSetManager';
@@ -32,11 +33,9 @@ export const createOrUpdateDataSet = ({
   // first create the dataset, since adding experiments with special key `[ALL]`
   // only works with edit operations
   if (!dataSetId) {
-    let { id } = await Ajax.post('/dataset/create/', {
-      data
-    });
-    dataSetId = id;
+    ({ id: dataSetId } = await createDataSet());
   }
+
   let { id, data: dataSet, ...dataSetDetails } = await updateDataSet(
     dataSetId,
     data,


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

We allow users to re-generate a dataset that has already expired.

https://github.com/AlexsLemonade/refinebio/pull/997 introduced changes that require two sepparate api calls to create a dataset with data

```
POST /dataset/create # creates it
PUT /dataset/{datasetid} # to edit it
```

## Types of changes

* [x] Bugfix (non-breaking change which fixes an issue)

## Functional tests

Tested locally

## Checklist

* [x] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
* [x] Any dependent changes have been merged and published in downstream modules

## Screenshots

![image](https://user-images.githubusercontent.com/1882507/52142194-03732000-2626-11e9-89b4-a8adcd22dbd8.png)

http://localhost:3000/dataset/4812fbf7-ff55-4e69-9db2-ed4ea7616d98
