### PR TITLE
Sort by the number of processed samples

### DIFF
--- a/src/containers/Results/index.js
+++ b/src/containers/Results/index.js
@@ -346,9 +346,9 @@ NoSearchResultsTooManyFilters = connect(
 let OrderingDropdown = ({ ordering, updateOrdering }) => {
   const options = [
     { label: 'Most No. of samples', value: Ordering.MostSamples },
-    { label: 'Least No. of samples', value: Ordering.LeastSamples },
-    { label: 'Newest Experiment First', value: Ordering.Newest },
-    { label: 'Oldest Experiment First', value: Ordering.Oldest }
+    { label: 'Least No. of samples', value: Ordering.LeastSamples }
+    // { label: 'Newest Experiment First', value: Ordering.Newest },
+    // { label: 'Oldest Experiment First', value: Ordering.Oldest }
   ];
 
   const selectedOption = options.find(x => x.value === ordering) || options[0];

--- a/src/containers/Results/index.js
+++ b/src/containers/Results/index.js
@@ -346,9 +346,9 @@ NoSearchResultsTooManyFilters = connect(
 let OrderingDropdown = ({ ordering, updateOrdering }) => {
   const options = [
     { label: 'Most No. of samples', value: Ordering.MostSamples },
-    { label: 'Least No. of samples', value: Ordering.LeastSamples }
-    // { label: 'Newest Experiment First', value: Ordering.Newest },
-    // { label: 'Oldest Experiment First', value: Ordering.Oldest }
+    { label: 'Least No. of samples', value: Ordering.LeastSamples },
+    { label: 'Newest Experiment First', value: Ordering.Newest },
+    { label: 'Oldest Experiment First', value: Ordering.Oldest }
   ];
 
   const selectedOption = options.find(x => x.value === ordering) || options[0];

--- a/src/state/search/actions.js
+++ b/src/state/search/actions.js
@@ -7,7 +7,7 @@ export const MOST_SAMPLES = 'MostSamples';
 
 export const Ordering = {
   MostSamples: '', // default sorting, so no parameters needed
-  LeastSamples: 'total_samples_count',
+  LeastSamples: 'num_processed_samples',
   Newest: '-source_first_published',
   Oldest: 'source_first_published'
 };
@@ -55,8 +55,9 @@ export function fetchResults({
         ...(query ? { search: query } : {}),
         limit: size,
         offset: (page - 1) * size,
-        num_processed_samples__gt: 0,
-        ...(ordering !== Ordering.MostSamples ? { ordering } : {}),
+        ...(ordering !== Ordering.MostSamples
+          ? { ordering }
+          : { ordering: '-num_processed_samples' }),
         ...appliedFilters
       });
 


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio-frontend/issues/506
close https://github.com/AlexsLemonade/refinebio-frontend/issues/537

## Purpose/Implementation Notes

This ensures that all experiments are displayed, even if they don't have any processed samples. If that's the case, they will be displayed at the end of the results when sorting by the number of samples.

This also removes sorting experiments by the publication date. We can bring these back when the API supports this scenario, ref https://github.com/AlexsLemonade/refinebio/issues/1018

## Types of changes

* [x] Bugfix (non-breaking change which fixes an issue)

## Functional tests

Test search

## Checklist

* [x] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
* [x] Any dependent changes have been merged and published in downstream modules

## Screenshots

![image](https://user-images.githubusercontent.com/1882507/52233561-6c100600-288d-11e9-931f-cf2a76826479.png)

![image](https://user-images.githubusercontent.com/1882507/52233590-792cf500-288d-11e9-9553-d2073bacb16f.png)
