### PR TITLE
Fixes for sample table columns

### DIFF
--- a/src/containers/Downloads/DownloadDetails.js
+++ b/src/containers/Downloads/DownloadDetails.js
@@ -285,6 +285,7 @@ class ExperimentsView extends React.Component {
                         onRefreshDataSet={onRefreshDataSet}
                         dataSet={{ [experiment.accession_code]: addedSamples }}
                         isImmutable={isImmutable}
+                        sampleMetadataFields={experiment.sample_metadata}
                       />
                     </div>
                   )}
@@ -354,6 +355,10 @@ class ExperimentsView extends React.Component {
  * while the modal is being displayed.
  */
 class ViewSamplesButtonModal extends React.Component {
+  static defaultProps = {
+    sampleMetadataFields: []
+  };
+
   state = {
     dataSet: {}
   };
@@ -387,6 +392,7 @@ class ViewSamplesButtonModal extends React.Component {
             experimentSampleAssociations={this.state.dataSet}
             fetchSampleParams={this.props.fetchSampleParams}
             isImmutable={this.props.isImmutable}
+            sampleMetadataFields={this.props.sampleMetadataFields}
           />
         )}
       </ModalManager>

--- a/src/containers/Experiment/SampleFieldMetadata.js
+++ b/src/containers/Experiment/SampleFieldMetadata.js
@@ -3,20 +3,6 @@
  */
 const SampleFieldMetadata = [
   {
-    Header: 'Title',
-    id: 'title',
-    accessor: d => d.title,
-    minWidth: 180
-  },
-  {
-    Header: 'Accession Code',
-    id: 'accession_code',
-    accessor: d => d.accession_code,
-    minWidth: 160,
-    width: 175,
-    style: { textAlign: 'right' }
-  },
-  {
     Header: 'Sex',
     id: 'sex',
     accessor: d => d.sex,

--- a/src/containers/Experiment/SampleFieldMetadata.js
+++ b/src/containers/Experiment/SampleFieldMetadata.js
@@ -3,6 +3,12 @@
  */
 const SampleFieldMetadata = [
   {
+    Header: 'Cell Line',
+    id: 'cell_line',
+    accessor: d => d.cell_line,
+    minWidth: 160
+  },
+  {
     Header: 'Sex',
     id: 'sex',
     accessor: d => d.sex,
@@ -36,12 +42,6 @@ const SampleFieldMetadata = [
     Header: 'Disease Stage',
     id: 'disease_stage',
     accessor: d => d.disease_stage,
-    minWidth: 160
-  },
-  {
-    Header: 'Cell Line',
-    id: 'cell_line',
-    accessor: d => d.cell_line,
     minWidth: 160
   },
   {

--- a/src/containers/Experiment/SamplesTable.js
+++ b/src/containers/Experiment/SamplesTable.js
@@ -29,7 +29,8 @@ class SamplesTable extends React.Component {
       <React.Fragment>
         Show {dropdown} of {totalSamples} Samples
       </React.Fragment>
-    )
+    ),
+    sampleMetadataFields: []
   };
 
   state = {
@@ -255,19 +256,12 @@ class SamplesTable extends React.Component {
     // 2. count the number of samples that have a value for each column
     let columns = SampleFieldMetadata.map(column => ({
       ...column,
-      __totalValues: data.reduce(
-        (total, sample) => total + (!!column.accessor(sample) ? 1 : 0),
-        0
-      ),
       Cell: CustomCell
     }));
 
-    columns = columns.sort(
-      (column1, column2) => column2.__totalValues - column1.__totalValues - 1
+    columns = columns.filter(c =>
+      this.props.sampleMetadataFields.includes(c.id)
     );
-
-    // 3. Filter out the columns that don't have a value
-    columns = columns.filter(column => column.__totalValues > 0);
 
     // Get the headers that do not depend on isImmutable first
     let headers = [
@@ -275,6 +269,22 @@ class SamplesTable extends React.Component {
         id: 'id',
         accessor: d => d.id,
         show: false
+      },
+      {
+        Header: 'Title',
+        id: 'title',
+        accessor: d => d.title,
+        minWidth: 180,
+        Cell: CustomCell
+      },
+      {
+        Header: 'Accession Code',
+        id: 'accession_code',
+        accessor: d => d.accession_code,
+        minWidth: 160,
+        width: 175,
+        style: { textAlign: 'right' },
+        Cell: CustomCell
       },
       ...columns,
       {

--- a/src/containers/Experiment/SamplesTable.js
+++ b/src/containers/Experiment/SamplesTable.js
@@ -251,17 +251,12 @@ class SamplesTable extends React.Component {
   _getColumns(data = []) {
     if (data.length === 0) return [];
 
-    const isImmutable = this.props.isImmutable;
-    // 1. define all columns
-    // 2. count the number of samples that have a value for each column
-    let columns = SampleFieldMetadata.map(column => ({
+    let columns = SampleFieldMetadata.filter(c =>
+      this.props.sampleMetadataFields.includes(c.id)
+    ).map(column => ({
       ...column,
       Cell: CustomCell
     }));
-
-    columns = columns.filter(c =>
-      this.props.sampleMetadataFields.includes(c.id)
-    );
 
     // Get the headers that do not depend on isImmutable first
     let headers = [
@@ -271,19 +266,19 @@ class SamplesTable extends React.Component {
         show: false
       },
       {
-        Header: 'Title',
-        id: 'title',
-        accessor: d => d.title,
-        minWidth: 180,
-        Cell: CustomCell
-      },
-      {
         Header: 'Accession Code',
         id: 'accession_code',
         accessor: d => d.accession_code,
         minWidth: 160,
         width: 175,
         style: { textAlign: 'right' },
+        Cell: CustomCell
+      },
+      {
+        Header: 'Title',
+        id: 'title',
+        accessor: d => d.title,
+        minWidth: 180,
         Cell: CustomCell
       },
       ...columns,
@@ -309,7 +304,7 @@ class SamplesTable extends React.Component {
     // In some instances like the DataSet page we want to hide the Add/Remove
     // buttons, but otherwise the Add/Remove column should be the first one.
     // If the list is not immutable, prepend the Add/Remove column to headers
-    if (!isImmutable) {
+    if (!this.props.isImmutable) {
       headers = [
         {
           Header: 'Add/Remove',

--- a/src/containers/Experiment/index.js
+++ b/src/containers/Experiment/index.js
@@ -307,6 +307,7 @@ class ExperimentSamplesTable extends React.Component {
 
     return (
       <SamplesTable
+        sampleMetadataFields={this.props.experiment.sample_metadata}
         experimentSampleAssociations={{
           [experiment.accession_code]: this.props.experiment.samples.map(
             x => x.accession_code


### PR DESCRIPTION
## Issue Number

close #514 
close #516 
close #513 

## Purpose/Implementation Notes

Stop calculating the column order dynamically in the `SamplesTable` and instead use the metadata fields provided by the API.

## Types of changes

* [x] Bugfix (non-breaking change which fixes an issue)

## Functional tests

Tested samples table in experiments page and in downloads page.

## Checklist

* [x] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
* [x] Any dependent changes have been merged and published in downstream modules

## Screenshots

![2019-02-05 14 07 25](https://user-images.githubusercontent.com/1882507/52297742-67138b00-294f-11e9-90b4-15de76b31601.gif)
