### PR TITLE
Show correct api version in the footer

### DIFF
--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -32,7 +32,9 @@ BUCKET_NAME=s3://$base_host
 
 yarn install --ignore-engines
 
-REACT_APP_API_HOST=https://api.$base_host yarn run cacheBackend
+VERSION=$(git describe --abbrev=0 --tags)
+
+VERSION=$VERSION REACT_APP_API_HOST=https://api.$base_host yarn run cacheBackend
 
 CI=false REACT_APP_API_HOST=https://api.$base_host yarn run build
 

--- a/cacheBackend.js
+++ b/cacheBackend.js
@@ -7,6 +7,7 @@
 const axios = require('axios');
 const fs = require('fs');
 
+const version = process.env.VERSION || '0.0.0';
 const ApiHost = process.env.REACT_APP_API_HOST || 'https://api.refine.bio';
 
 console.log('Fetching data to be cached from endpoint: ' + ApiHost);
@@ -29,10 +30,18 @@ Promise.all([
   axios
     .get(ApiHost + '/search/?limit=1&offset=0')
     .then(function(response) {
-      return response.data.filters.organism;
+      return {
+        organism: response.data.filters.organism,
+        apiVersion: response.headers['x-source-revision']
+      };
     })
     .catch(error => false)
-]).then(function([stats, organism]) {
-  const cache = { stats, organism };
+]).then(function([stats, { organism, apiVersion }]) {
+  const cache = {
+    version: version, // remove `v` at the start of each version
+    apiVersion: apiVersion,
+    stats,
+    organism
+  };
   fs.writeFileSync(`src/apiData.json`, JSON.stringify(cache));
 });

--- a/src/components/Footer/index.js
+++ b/src/components/Footer/index.js
@@ -3,6 +3,8 @@ import FundIcon from '../../common/icons/fund-icon.svg';
 import { Link } from 'react-router-dom';
 import './Footer.scss';
 
+import apiData from '../../apiData.json';
+
 const Footer = () => (
   <footer className="footer">
     <div className="footer__container footer__container--main footer__flex">
@@ -86,7 +88,11 @@ const Footer = () => (
       <a className="footer__link" href="mailto:ccdl@alexslemonade.org">
         Contact
       </a>
-      <div className="footer__version">Version 24354-23111</div>
+      {apiData.version && apiData.apiVersion && (
+        <div className="footer__version">
+          Version {apiData.apiVersion.substr(1)} - {apiData.version.substr(1)}
+        </div>
+      )}
     </div>
   </footer>
 );


### PR DESCRIPTION
## Issue Number

Close #527 

## Purpose/Implementation Notes

Modifies deploy script to cache the api version and the frontend version, and displays both in the footer.

## Types of changes
* [x] New feature (non-breaking change which adds functionality)

## Checklist

* [x] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
* [x] Any dependent changes have been merged and published in downstream modules

## Screenshots

`Version 1.7.11-hotfix - 1.0.66`

![image](https://user-images.githubusercontent.com/1882507/52664698-b1f54b80-2ed7-11e9-9663-76287e1a576b.png)

