### PR TITLE
Detect accession code and show top result

### DIFF
--- a/src/components/SearchInput/index.js
+++ b/src/components/SearchInput/index.js
@@ -22,7 +22,7 @@ export default class SearchInput extends Component {
       <Formik
         ref={this.formik}
         initialValues={{ search: this.props.searchTerm }}
-        onSubmit={({ search }) => this.props.onSubmit(search)}
+        onSubmit={({ search }) => this.props.onSubmit(search.trim())}
       >
         {() => (
           <Form className="search-input">

--- a/src/pages/Search/Result/index.js
+++ b/src/pages/Search/Result/index.js
@@ -28,7 +28,7 @@ const Result = ({ result, query }) => {
               className="result__icon"
               alt="accession-icon"
             />{' '}
-            {result.accession_code}
+            <HighlightedText text={result.accession_code} highlight={query} />
           </div>
           <Link
             className="link result__title"

--- a/src/pages/Search/SearchResults.scss
+++ b/src/pages/Search/SearchResults.scss
@@ -152,4 +152,18 @@
       margin-right: 24px;
     }
   }
+
+  &__related-block {
+    margin-top: 56px;
+    margin-bottom: 32px;
+    font-size: 1.25rem;
+    text-align: left;
+    border-bottom: 2px solid #f2f2f2;
+    line-height: 0;
+
+    &:first-line {
+      background-color: white;
+      padding-right: 8px;
+    }
+  }
 }

--- a/src/pages/Search/index.js
+++ b/src/pages/Search/index.js
@@ -146,12 +146,18 @@ class SearchResults extends Component {
                   </div>
                   <ResultFilters appliedFilters={this.state.filters} />
                   <div className="results__list">
-                    {results.map(result => (
-                      <Result
-                        key={result.accession_code}
-                        result={result}
-                        query={this.state.query}
-                      />
+                    {results.map((result, index) => (
+                      <React.Fragment key={result.accession_code}>
+                        <Result result={result} query={this.state.query} />
+
+                        {result._isTopResult &&
+                          results[index + 1] &&
+                          !results[index + 1]._isTopResult && (
+                            <div className="results__related-block">
+                              Other results matching '{this.state.query}'
+                            </div>
+                          )}
+                      </React.Fragment>
                     ))}
                     <Pagination
                       onPaginate={updatePage}


### PR DESCRIPTION
## Issue Number

close #519 

## Purpose/Implementation Notes

Detects when an user is searching for an accession code, and make an additional API query to retrieve the experiments matching that accession code.

One part that I'm not completely sure is the part to detect what is an accession code. I used this regular expression:

https://github.com/AlexsLemonade/refinebio-frontend/blob/f47365601cbc5d42a1d19df457262faba8ab61e6/src/state/search/actions.js#L46

This will match accession codes with the following:

- `{GSE | ERP | SRP}{3 to 6 digits}`
- `E-{4 upper case letters}-{2 to 4 digits}`

## Types of changes

* [x] New feature (non-breaking change which adds functionality)

## Functional tests

Search for accession code

## Checklist

* [x] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
* [x] Any dependent changes have been merged and published in downstream modules

## Screenshots

![image](https://user-images.githubusercontent.com/1882507/53104606-aae4c380-34fd-11e9-9de4-5b13651bd6c8.png)
