### PR TITLE
Redirect to `/search` from `/ results`

### DIFF
--- a/src/pages/App.js
+++ b/src/pages/App.js
@@ -2,7 +2,7 @@ import React from 'react';
 import Helmet from 'react-helmet';
 import { Provider } from 'react-redux';
 import classnames from 'classnames';
-import { Router, Route, Switch } from 'react-router-dom';
+import { Router, Route, Switch, Redirect } from 'react-router-dom';
 
 import history from '../history';
 import store from '../store/store';
@@ -31,6 +31,10 @@ import './App.scss';
 const AppContent = () => (
   <div className="layout__content">
     <Switch>
+      <Route
+        path="/results"
+        render={props => <Redirect to={`/search${props.location.search}`} />}
+      />
       <Route path="/search" component={Search} />
       <Route path="/dashboard" component={Dashboard} />
       <Route path="/executive-dashboard" component={ExecutiveDashboard} />


### PR DESCRIPTION
## Issue Number

close #554 

## Purpose/Implementation Notes

We changed the search page from `/results` to `/search` but google has some of the old urls indexed. This ensures we redirect appropriately.

## Types of changes

* [x] Bugfix (non-breaking change which fixes an issue)

## Functional tests

Visit `/results?q=human`

## Checklist

* [x] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
* [x] Any dependent changes have been merged and published in downstream modules
