### PR TITLE
Arielsvn/support/qn targets

### DIFF
--- a/cacheBackend.js
+++ b/cacheBackend.js
@@ -41,13 +41,21 @@ async function cacheServerData() {
           apiVersion: response.headers['x-source-revision']
         };
       })
-      .catch(error => false)
-  ]).then(function([stats, { organism, apiVersion }]) {
+      .catch(error => false),
+    axios
+      .get(ApiHost + '/qn_targets_available')
+      .then(response => response.data)
+      .catch(_ => [])
+  ]).then(function([stats, { organism, apiVersion }, qnTargets]) {
     const cache = {
       version: version, // remove `v` at the start of each version
       apiVersion: apiVersion,
       stats,
-      organism
+      organism,
+      qnTargets: qnTargets.reduce(
+        (accum, organism) => ({ ...accum, [organism.name]: true }),
+        {}
+      )
     };
     fs.writeFileSync(`src/apiData.json`, JSON.stringify(cache));
   });

--- a/src/components/SamplesTable/SamplesTable.js
+++ b/src/components/SamplesTable/SamplesTable.js
@@ -20,6 +20,7 @@ import SampleDetailsLoader from './SampleDetailsLoader';
 import { formatSentenceCase } from '../../common/helpers';
 import debounce from 'lodash/debounce';
 import { IoIosArrowUp, IoIosArrowDown } from 'react-icons/io';
+import apiData from '../../apiData.json';
 
 class SamplesTable extends React.Component {
   static defaultProps = {
@@ -302,7 +303,11 @@ function AddRemoveCell({ sample, experimentAccessionCodes }) {
     {}
   );
 
-  if (!sample.is_processed) {
+  // ensure the samples have qn targets associated
+  if (
+    !sample.is_processed ||
+    (apiData.qnTargets && !apiData.qnTargets[sample.organism.name])
+  ) {
     return (
       <div className="sample-not-processed info">
         <img className="info__icon" src={InfoIcon} alt="" />

--- a/src/pages/Experiment/index.js
+++ b/src/pages/Experiment/index.js
@@ -66,7 +66,7 @@ let Experiment = ({ match, location: { search, state }, goBack }) => {
           let displaySpinner = isLoading;
           let experimentData = experiment || { samples: [] };
           let totalSamples = experimentData.samples.length;
-          let processedSamples = experimentData.samples.filter(
+          let totalProcessedSamples = experimentData.samples.filter(
             x => x.is_processed
           ).length;
           let organisms = experimentData.organisms;
@@ -125,9 +125,10 @@ let Experiment = ({ match, location: { search, state }, goBack }) => {
                     <div>
                       <DataSetSampleActions
                         dataSetSlice={{
-                          [experimentData.accession_code]: DataSetStats.mapAccessions(
-                            experimentData.samples
-                          )
+                          [experimentData.accession_code]: {
+                            all: true,
+                            total: totalProcessedSamples
+                          }
                         }}
                       />
                     </div>
@@ -152,7 +153,7 @@ let Experiment = ({ match, location: { search, state }, goBack }) => {
                         className="experiment__stats-icon"
                         alt="Sample Icon"
                       />{' '}
-                      <NDownloadableSamples total={processedSamples} />
+                      <NDownloadableSamples total={totalProcessedSamples} />
                     </div>
 
                     <div
@@ -325,6 +326,9 @@ function SamplesTableBlock({ experiment }) {
   const style = expanded
     ? { maxWidth: Math.max(1175, maxTableWidth(totalColumns)) }
     : {};
+  let totalProcessedSamples = experiment
+    ? experiment.samples.filter(x => x.is_processed).length
+    : 0;
 
   return (
     <div
@@ -339,9 +343,10 @@ function SamplesTableBlock({ experiment }) {
               {experiment && (
                 <DataSetSampleActions
                   dataSetSlice={{
-                    [experiment.accession_code]: DataSetStats.mapAccessions(
-                      experiment.samples
-                    )
+                    [experiment.accession_code]: {
+                      all: true,
+                      total: totalProcessedSamples
+                    }
                   }}
                 />
               )}


### PR DESCRIPTION
## Issue Number

close https://github.com/AlexsLemonade/refinebio/issues/644


## Purpose/Implementation Notes

Depends on changes from https://github.com/AlexsLemonade/refinebio/pull/1090.

At deploy time, the app queries `/qn_targets_available` and then makes sure that the samples with no QN targets associated are displayed as not processed in the samples table.

## Types of changes

* [x] New feature (non-breaking change which adds functionality)

## Functional tests

Test adding samples on results and experiments page.

## Checklist

* [x] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
* [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

![image](https://user-images.githubusercontent.com/1882507/54056134-2eb8d400-41bd-11e9-83bc-fa0348f22d36.png)
