### PR TITLE
Show sample counts in search filters

### DIFF
--- a/src/pages/Search/ResultFilters/FilterCategory.js
+++ b/src/pages/Search/ResultFilters/FilterCategory.js
@@ -56,7 +56,6 @@ class FilterCategory extends React.Component {
                   key={filter}
                   name={filter}
                   className="result-filters__filter-check"
-                  disabled={categoryFilters[filter] === 0}
                   onChange={() =>
                     toggledFilter(
                       category.queryField,
@@ -79,19 +78,20 @@ class FilterCategory extends React.Component {
               ) : null // Do not display a checkbox if the filter is null
           )}
 
-        {filters.length > MAX_FILTERS && !this.state.query && (
-          <Button
-            text={
-              this.state.collapsed
-                ? `+ ${filters.length - MAX_FILTERS} more`
-                : `- see less`
-            }
-            buttonStyle="link"
-            onClick={() =>
-              this.setState(state => ({ collapsed: !state.collapsed }))
-            }
-          />
-        )}
+        {filters.length > MAX_FILTERS &&
+          !this.state.query && (
+            <Button
+              text={
+                this.state.collapsed
+                  ? `+ ${filters.length - MAX_FILTERS} more`
+                  : `- see less`
+              }
+              buttonStyle="link"
+              onClick={() =>
+                this.setState(state => ({ collapsed: !state.collapsed }))
+              }
+            />
+          )}
       </section>
     );
   }

--- a/src/state/search/actions.js
+++ b/src/state/search/actions.js
@@ -1,5 +1,3 @@
-import pickBy from 'lodash/pickBy';
-
 import { push } from '../routerActions';
 import { getQueryString, Ajax } from '../../common/helpers';
 import reportError from '../reportError';

--- a/src/state/search/actions.js
+++ b/src/state/search/actions.js
@@ -1,3 +1,5 @@
+import pickBy from 'lodash/pickBy';
+
 import { push } from '../routerActions';
 import { getQueryString, Ajax } from '../../common/helpers';
 import reportError from '../reportError';
@@ -85,7 +87,7 @@ export function fetchResults({
         results = [...topResults, ...results];
       }
 
-      let filters = transformElasticSearchFacets(facets);
+      let filters = transformFacets(facets);
 
       if (filterOrder.length > 0) {
         // merge both filter objects to enable interactive filtering
@@ -102,7 +104,7 @@ export function fetchResults({
               [lastFilterName]: undefined
             }
           });
-          previousFilters = transformElasticSearchFacets(previousFacets);
+          previousFilters = transformFacets(previousFacets);
         }
 
         filters = {
@@ -140,35 +142,18 @@ export function fetchResults({
 }
 
 /**
- * Ideally the filters should be formatted in the backend, but that seemed to be difficult
- * with elastic search https://github.com/AlexsLemonade/refinebio/pull/974#issuecomment-456533392
+ * Transform filters object that is sent from the API
  */
-function transformElasticSearchFacets(facets) {
+function transformFacets(facets) {
   return {
-    organism: transformFacet(
-      facets['_filter_organism_names']['organism_names']
-    ),
-    technology: transformFacet(facets['_filter_technology']['technology']),
-    publication: transformHasPublicationFacet(
-      facets['_filter_has_publication']['has_publication']
-    ),
-    platform: transformFacet(facets['_filter_platform_names']['platform_names'])
+    organism: facets['organism_names'],
+    // We want to hide `Unknown` from the technologies if it has 0 processed samples
+    technology: facets['technology'], // pickBy(facets['technology'], totalSamples => totalSamples > 0),
+    publication: facets['has_publication']
+      ? { has_publication: facets['has_publication']['true'] || 0 }
+      : null,
+    platform: facets['platform_names']
   };
-}
-
-function transformFacet(facet) {
-  const result = {};
-  for (let item of facet.buckets) {
-    result[item.key] = item.doc_count;
-  }
-
-  return result;
-}
-
-function transformHasPublicationFacet(facet) {
-  if (!facet.buckets || !facet.buckets.length) return null;
-  const activeBucket = facet.buckets.find(bucket => bucket.key === 1);
-  return activeBucket && { has_publication: activeBucket.doc_count };
 }
 
 export const triggerSearch = searchTerm => (dispatch, getState) => {

--- a/src/state/search/actions.js
+++ b/src/state/search/actions.js
@@ -2,6 +2,7 @@ import { push } from '../routerActions';
 import { getQueryString, Ajax } from '../../common/helpers';
 import reportError from '../reportError';
 import { getUrlParams } from './reducer';
+import pickBy from 'lodash/pickBy';
 
 export const MOST_SAMPLES = 'MostSamples';
 
@@ -146,7 +147,7 @@ function transformFacets(facets) {
   return {
     organism: facets['organism_names'],
     // We want to hide `Unknown` from the technologies if it has 0 processed samples
-    technology: facets['technology'], // pickBy(facets['technology'], totalSamples => totalSamples > 0),
+    technology: pickBy(facets['technology'], totalSamples => totalSamples > 0),
     publication: facets['has_publication']
       ? { has_publication: facets['has_publication']['true'] || 0 }
       : null,


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio/issues/1063

## Purpose/Implementation Notes

https://github.com/AlexsLemonade/refinebio/pull/1124 changes the api to return sample counts in the filters. This updates the FE to handle those changes.

## Types of changes

* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

* [x] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
* [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

![image](https://user-images.githubusercontent.com/1882507/54383749-1dfad900-4669-11e9-8510-455c9b47be87.png)
