### PR TITLE
Fix typo in api key header

### DIFF
--- a/src/state/download/actions.js
+++ b/src/state/download/actions.js
@@ -250,7 +250,7 @@ export const startDownload = ({
         ...(email ? { email_address: email } : {})
       },
       {
-        API_KEY: tokenId
+        'API-KEY': tokenId
       }
     );
   } catch (e) {


### PR DESCRIPTION
Hotfix - noticed this in prod when creating a dataset.