### PR TITLE
Persist email address in localstorage

### DIFF
--- a/src/common/hooks.js
+++ b/src/common/hooks.js
@@ -51,3 +51,44 @@ export function useHistory() {
     params: getQueryParamObject(history.location.search)
   };
 }
+
+/**
+ * Thanks to https://usehooks.com/useLocalStorage
+ * @param {*} key
+ * @param {*} initialValue
+ */
+export function useLocalStorage(key, initialValue) {
+  // State to store our value
+  // Pass initial state function to useState so logic is only executed once
+  const [storedValue, setStoredValue] = React.useState(() => {
+    try {
+      // Get from local storage by key
+      const item = window.localStorage.getItem(key);
+      // Parse stored json or if none return initialValue
+      return item ? JSON.parse(item) : initialValue;
+    } catch (error) {
+      // If error also return initialValue
+      console.log(error);
+      return initialValue;
+    }
+  });
+
+  // Return a wrapped version of useState's setter function that ...
+  // ... persists the new value to localStorage.
+  const setValue = value => {
+    try {
+      // Allow value to be a function so we have same API as useState
+      const valueToStore =
+        value instanceof Function ? value(storedValue) : value;
+      // Save state
+      setStoredValue(valueToStore);
+      // Save to local storage
+      window.localStorage.setItem(key, JSON.stringify(valueToStore));
+    } catch (error) {
+      // A more advanced implementation would handle the error case
+      console.log(error);
+    }
+  };
+
+  return [storedValue, setValue];
+}

--- a/src/pages/Downloads/DownloadStart/DownloadStart.js
+++ b/src/pages/Downloads/DownloadStart/DownloadStart.js
@@ -10,56 +10,56 @@ import { connect } from 'react-redux';
 import ProcessingImage from './download-processing.svg';
 import { startDownload } from '../../../state/download/actions';
 import EmailForm from './EmailForm';
+import { useLocalStorage } from '../../../common/hooks';
 
 /**
  * This component gets rendereded in the DataSet page, when no email has been assigned
  */
-class DownloadStart extends React.PureComponent {
-  render() {
-    const { dataSetId } = this.props;
-    return (
-      <div className="dataset__container">
-        <div className="dataset__message">
-          <div>
-            <Helmet>
-              <title>Download - refine.bio</title>
-            </Helmet>
-            <h1>
-              We're almost ready to start putting your download files together!
-            </h1>
-            <h2>
-              Enter your email and we will send you the download link when your
-              files are ready. It usually takes about 15-20 minutes.
-            </h2>
-            <EmailForm
-              dataSetId={dataSetId}
-              agreedToTerms={this.props.agreedToTerms}
-              onSubmit={data => this._submitEmailForm(data)}
-            />
-            <div className="dataset__image">
-              <img
-                src={ProcessingImage}
-                alt="We're processing your download file"
-                className="img-responsive"
-              />
-            </div>
-          </div>
-        </div>
-      </div>
-    );
-  }
-
-  async _submitEmailForm({ email, termsOfService, receiveUpdates }) {
-    const { dataSetId, dataSet } = this.props;
-    return await this.props.startDownload({
+let DownloadStart = ({ dataSetId, dataSet, agreedToTerms, startDownload }) => {
+  let [emailAddress, setEmailAddress] = useLocalStorage('email-address', '');
+  let submitEmailForm = async ({ email, termsOfService, receiveUpdates }) => {
+    setEmailAddress(email);
+    return await startDownload({
       email,
       termsOfService,
       receiveUpdates,
       dataSetId,
       dataSet
     });
-  }
-}
+  };
+
+  return (
+    <div className="dataset__container">
+      <div className="dataset__message">
+        <div>
+          <Helmet>
+            <title>Download - refine.bio</title>
+          </Helmet>
+          <h1>
+            We're almost ready to start putting your download files together!
+          </h1>
+          <h2>
+            Enter your email and we will send you the download link when your
+            files are ready. It usually takes about 15-20 minutes.
+          </h2>
+          <EmailForm
+            dataSetId={dataSetId}
+            emailAddress={emailAddress}
+            agreedToTerms={agreedToTerms}
+            onSubmit={data => submitEmailForm(data)}
+          />
+          <div className="dataset__image">
+            <img
+              src={ProcessingImage}
+              alt="We're processing your download file"
+              className="img-responsive"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
 DownloadStart = connect(
   state => ({
     agreedToTerms: !!state.token

--- a/src/pages/Downloads/DownloadStart/EmailForm.js
+++ b/src/pages/Downloads/DownloadStart/EmailForm.js
@@ -11,7 +11,7 @@ import Error from '../../../components/Error';
 /**
  * This form can be used to edit the email that's associated with a dataset
  */
-let EmailForm = ({ onSubmit, agreedToTerms }) => (
+let EmailForm = ({ onSubmit, agreedToTerms, emailAddress }) => (
   <Formik
     onSubmit={async (values, { setErrors, setValues, setSubmitting }) => {
       try {
@@ -37,7 +37,7 @@ let EmailForm = ({ onSubmit, agreedToTerms }) => (
     }}
     initialValues={{
       receiveUpdates: true,
-      email: '',
+      email: emailAddress,
       termsOfService: agreedToTerms
     }}
     validationSchema={Yup.object().shape({
@@ -96,15 +96,18 @@ let EmailForm = ({ onSubmit, agreedToTerms }) => (
             </Checkbox>
           </div>
         )}
-        <div>
-          <Checkbox
-            name="receiveUpdates"
-            checked={values.receiveUpdates}
-            onChange={handleChange}
-          >
-            I would like to receive occasional updates from the refine.bio team
-          </Checkbox>
-        </div>
+        {(emailAddress === '' || values.email !== emailAddress) && (
+          <div>
+            <Checkbox
+              name="receiveUpdates"
+              checked={values.receiveUpdates}
+              onChange={handleChange}
+            >
+              I would like to receive occasional updates from the refine.bio
+              team
+            </Checkbox>
+          </div>
+        )}
       </Form>
     )}
   </Formik>


### PR DESCRIPTION
## Issue Number

close #507 

## Purpose/Implementation Notes

Persists the user email address so that it's pre-populated on the next downloads. Also hides the checkbox to get alerts for users that downloaded a dataset.

## Types of changes

* [x] New feature (non-breaking change which adds functionality)

## Functional tests

Download a dataset, and try downloading a second one, the email address should already be there.

## Checklist

* [x] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
* [x] Any dependent changes have been merged and published in downstream modules

## Screenshots

![2019-04-03 12 45 04](https://user-images.githubusercontent.com/1882507/55497023-59f0e080-560e-11e9-9377-f051c243a20e.gif)
