### PR TITLE
Fix regenerate dataset button

### DIFF
--- a/src/pages/Downloads/DataSet/index.js
+++ b/src/pages/Downloads/DataSet/index.js
@@ -116,7 +116,7 @@ function DataSetPageHeader({ dataSetId, email_address, hasError, dataSet }) {
     is_available && !isExpired ? (
       <DataSetReady dataSet={dataSet} />
     ) : (
-      <DataSetExpired />
+      <DataSetExpired dataSet={dataSet} />
     )
   ) : is_processing ? (
     <DataSetProcessing email={email_address} dataSetId={dataSetId} />
@@ -285,7 +285,7 @@ DataSetReady = connect(
   }
 )(DataSetReady);
 
-let DataSetExpired = ({ regenerateDataSet }) => (
+let DataSetExpired = ({ dataSet, regenerateDataSet }) => (
   <div className="dataset__container">
     <div className="dataset__message">
       <div className="dataset__way-container">
@@ -295,7 +295,9 @@ let DataSetExpired = ({ regenerateDataSet }) => (
             The download files for this dataset isn’t available anymore
           </div>
           <div className="dataset__way-container">
-            <Button onClick={regenerateDataSet}>Regenerate Files</Button>
+            <Button onClick={() => regenerateDataSet(dataSet)}>
+              Regenerate Files
+            </Button>
           </div>
         </div>
 

--- a/src/state/download/actions.js
+++ b/src/state/download/actions.js
@@ -290,10 +290,10 @@ export const startDownload = ({
 
 /**
  * Once generated the datasets are immutable on the server, so to be able to re-generate one we have
- * to create a new dataset and redirect to the associated page.
+ * to create a new dataset with the same data and redirect to it's page.
  */
-export const regenerateDataSet = () => async (dispatch, getState) => {
-  let { data, aggregate_by, scale_by } = getState().dataSet;
+export const regenerateDataSet = dataSet => async (dispatch, getState) => {
+  let { data, aggregate_by, scale_by } = dataSet;
 
   try {
     // 1. create a new dataset


### PR DESCRIPTION
## Issue Number

close #606 

## Purpose/Implementation Notes

Ensures that datasets can be recreated.

## Types of changes

* [x] Bugfix (non-breaking change which fixes an issue)

## Functional tests

Go to an expired dataset (`/dataset/d46168d9-fe99-4f03-bd57-0aa8d360708b`) and regenerate it

## Checklist

* [x] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
* [x] Any dependent changes have been merged and published in downstream modules

## Screenshots

![2019-04-25 12 36 46](https://user-images.githubusercontent.com/1882507/56752695-ddf24000-6756-11e9-9a43-5bb245805be5.gif)

api was a bit slow...

