### PR TITLE
new search defaults to best match

### DIFF
--- a/src/state/search/actions.js
+++ b/src/state/search/actions.js
@@ -167,7 +167,7 @@ export const triggerSearch = searchTerm => (dispatch, getState) => {
       query: searchTerm,
       page: 1,
       filters: {},
-      ordering: Ordering.MostSamples,
+      ordering: Ordering.BestMatch,
     })
   );
 };


### PR DESCRIPTION
## Issue Number
#638 

## Purpose/Implementation Notes

When trigger search is called (when a new search is submitted from search results page) the ordering is set to Ordering.MostSamples. This changes that to use Ordering.BestResults instead. 

What types of changes does your code introduce?

* [ x] Bugfix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

This is untested and I haven't set up anything locally.

## Checklist

* [ ] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
* [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

None
