### PR TITLE
wrap useEffect callback in React.useCallback

### DIFF
--- a/src/components/Loader/index.js
+++ b/src/components/Loader/index.js
@@ -110,20 +110,19 @@ export function useLoader(fetch, updateProps = []) {
     [fetch, state]
   );
 
-  React.useEffect(
-    () => {
+  const refreshDataCallback = React.useCallback(
+    function incrementAndFetchData() {
       mounted.current += 1;
       fetchDataCallback(mounted.current);
     },
-    updateProps // eslint-disable-line react-hooks/exhaustive-deps
+    [fetchDataCallback]
   );
+
+  React.useEffect(refreshDataCallback, updateProps);
 
   return {
     ...state,
     hasError: !!state.error,
-    refresh: async () => {
-      mounted.current += 1;
-      await fetchDataCallback(mounted.current);
-    },
+    refresh: refreshDataCallback,
   };
 }


### PR DESCRIPTION
## Issue Number
#648

## Purpose/Implementation Notes
This is an attempt to make the linter not helicopter parent with the added benefit of not sending an API request every time the screen refreshes.

This has the same functionality as #646 without manually silencing the linter. After reading the docs I honestly can't tell if this is how it's meant to be implemented or just a sanctioned workaround. 

Essentially the changes are:
1) React.useEffect calls refreshDataCallback with updateProps as a dependency
2) Adds new function called refreshDataCallback that encapsulates the incrementing of 'mounted.current' and fetchDataCallback's invocation into its own React.useCallback to be used when manually refreshing or refreshing from a change in one of passed in 'updateProps'. 

## Types of changes

* [x] Bugfix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests
  The setInterval refresh() and the range select on the dashboard look to be functional.
  I also tried to abuse the range select but the most recent range fetched was always the one rendered.
  
  Tested Here:
    -src/pages/Dashboard/index.js
  Still needs to be tested here:
    -src/pages/ExecDashboard/index.js
    -src/pages/ExecDashboard/SamplesProcessedBlock.js
    -src/pages/SpeciesCompendia/DownloadCompendia.js

## Checklist
* [x] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
* [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots
Sadly, no.

