### PR TITLE
Arielsvn/648 useloader fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "test:integration": "jest --runInBand -c integration/jest.config.js"
   },
   "devDependencies": {
+    "@testing-library/react": "^8.0.1",
     "axios": "^0.18.0",
     "eslint": "^5.16.0",
     "eslint-config-airbnb": "^17.1.0",
@@ -69,6 +70,7 @@
     "eslint-plugin-react-hooks": "^1.6.0",
     "flow-bin": "^0.68.0",
     "husky": "^1.3.1",
+    "jest-dom": "^3.4.0",
     "jest-puppeteer": "^3.7.0",
     "lint-staged": "^7.0.0",
     "node-sass": "^4.11.0",

--- a/src/common/helpers.test.js
+++ b/src/common/helpers.test.js
@@ -61,7 +61,7 @@ describe('getQueryParamObject', () => {
 });
 
 describe('Ajax', () => {
-  beforeEach(function() {
+  beforeEach(() => {
     global.fetch = jest
       .fn()
       .mockImplementation(() => Promise.resolve({ ok: true, json: () => {} }));

--- a/src/components/Loader/index.js
+++ b/src/components/Loader/index.js
@@ -139,7 +139,7 @@ export function useLoader(fetch, updateProps = []) {
 
   React.useEffect(() => {
     fetchDataCallback();
-  }, [fetchDataCallback, ...updateProps]);
+  }, [fetchDataCallback, ...updateProps]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return {
     ...state,

--- a/src/components/Loader/loader.test.js
+++ b/src/components/Loader/loader.test.js
@@ -1,0 +1,77 @@
+import React from 'react';
+import {
+  render,
+  fireEvent,
+  cleanup,
+  waitForElement,
+} from '@testing-library/react';
+import 'jest-dom/extend-expect';
+
+import { useLoader } from './index';
+
+function MockLoader({ fetch }) {
+  const [id, setId] = React.useState(1);
+  const { data, isLoading, refresh } = useLoader(fetch, [id]);
+  return (
+    <div>
+      {!isLoading && <p data-testid="result">{data}</p>}
+      <button type="button" onClick={refresh}>
+        refresh
+      </button>
+      {/* update a dependency of the loader */}
+      <button type="button" onClick={() => setId(id + 1)}>
+        update
+      </button>
+    </div>
+  );
+}
+
+describe('useLoader', () => {
+  afterEach(cleanup);
+
+  // This throws a warning:
+  // Warning: An update to MockLoader inside a test was not wrapped in act
+  // Couldn't find a way around it https://github.com/testing-library/react-testing-library/issues/281#issuecomment-461150694
+  it('calls fetch a single time when loaded', async () => {
+    const DATA = 101;
+    const mockCallback = jest.fn(x => DATA);
+    const { getByTestId } = render(<MockLoader fetch={mockCallback} />);
+    await waitForElement(() => getByTestId('result'));
+    expect(getByTestId('result')).toHaveTextContent(DATA);
+    expect(mockCallback).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls fetch when refresh is executed', async () => {
+    let data = 101;
+    const mockCallback = jest.fn(x => data);
+    const { getByTestId, getByText } = render(
+      <MockLoader fetch={mockCallback} />
+    );
+    await waitForElement(() => getByTestId('result'));
+
+    // modify the response
+    data = 'another value';
+    fireEvent.click(getByText(/refresh/i));
+    await waitForElement(() => getByTestId('result'));
+
+    expect(getByTestId('result')).toHaveTextContent(data);
+    expect(mockCallback).toHaveBeenCalledTimes(2);
+  });
+
+  it('calls fetch when a dependency changes', async () => {
+    let data = 101;
+    const mockCallback = jest.fn(x => data);
+    const { getByTestId, getByText } = render(
+      <MockLoader fetch={mockCallback} />
+    );
+    await waitForElement(() => getByTestId('result'));
+
+    // this updates `id` which is one of the dependencies of the effect
+    data = 'another value';
+    fireEvent.click(getByText(/update/i));
+    await waitForElement(() => getByTestId('result'));
+
+    expect(getByTestId('result')).toHaveTextContent(data);
+    expect(mockCallback).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/pages/Dashboard/index.js
+++ b/src/pages/Dashboard/index.js
@@ -17,11 +17,12 @@ function Dashboard(props) {
     rangeParam = 'day';
   }
   const [range, setRange] = React.useState(rangeParam);
-  const { data, refresh, hasError } = useLoader(async () => {
+  const fetchCallback = React.useCallback(async () => {
     const stats = await fetchDashboardData(range);
     setChartUpdating(false);
     return getDashboardChartConfig(stats, range);
   }, [range]);
+  const { data, refresh, hasError } = useLoader(fetchCallback, [range]);
 
   // refresh data every 10 mins
   useInterval(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -859,7 +859,7 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.3.1", "@babel/runtime@^7.3.4", "@babel/runtime@^7.4.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.3.1", "@babel/runtime@^7.3.4", "@babel/runtime@^7.4.2", "@babel/runtime@^7.4.5":
   version "7.4.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.4.5.tgz#582bb531f5f9dc67d2fcb682979894f75e253f12"
   integrity sha512-TuI4qpWZP6lGOGIuGWtp9sPluqYICmbk8T/1vpSysqJxRPkudh/ofFWyqdcMsDf2s7KvDL4/YHgKyvcS3g9CJQ==
@@ -1161,6 +1161,11 @@
     "@sentry/types" "4.5.3"
     tslib "^1.9.3"
 
+"@sheerun/mutationobserver-shim@^0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz#8013f2af54a2b7d735f71560ff360d3a8176a87b"
+  integrity sha512-vTCdPp/T/Q3oSqwHmZ5Kpa9oI7iLtGl3RQaA/NyLHikvcrPxACkkKVr/XzkSPJWXHRhKGzVvb0urJsbMlRxi1Q==
+
 "@svgr/babel-plugin-add-jsx-attribute@^4.2.0":
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-4.2.0.tgz#dadcb6218503532d6884b210e7f3c502caaa44b1"
@@ -1265,6 +1270,24 @@
     "@svgr/plugin-jsx" "^4.1.0"
     "@svgr/plugin-svgo" "^4.0.3"
     loader-utils "^1.1.0"
+
+"@testing-library/dom@^5.0.0":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-5.0.1.tgz#1673a56f27fd9748576495958a27b0e5a408db5d"
+  integrity sha512-HmyN4b/PmSaSB1ku0tWjgnTtyrwNBXEpp44wgfNaDhyj6IJTCWp1GAf4AANoLGItgMsYjepwWOdMyuJ/8iyStQ==
+  dependencies:
+    "@babel/runtime" "^7.4.5"
+    "@sheerun/mutationobserver-shim" "^0.3.2"
+    pretty-format "^24.8.0"
+    wait-for-expect "^1.2.0"
+
+"@testing-library/react@^8.0.1":
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-8.0.1.tgz#91c254adf855b13de50020613cb5d3915f9f7875"
+  integrity sha512-N/1pJfhEnNYkGyxuw4xbp03evaS0z/CT8o0QgTfJqGlukAcU15xf9uU1w03NHKZJcU69nOCBAoAkXHtHzYwMbg==
+  dependencies:
+    "@babel/runtime" "^7.4.5"
+    "@testing-library/dom" "^5.0.0"
 
 "@types/babel__core@^7.1.0":
   version "7.1.2"
@@ -3093,6 +3116,21 @@ css-what@2.1, css-what@^2.1.2:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.3.tgz#a6d7604573365fe74686c3f311c56513d88285f2"
   integrity sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==
+
+css.escape@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
+  integrity sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=
+
+css@^2.2.3:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/css/-/css-2.2.4.tgz#c646755c73971f2bba6a601e2cf2fd71b1298929"
+  integrity sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==
+  dependencies:
+    inherits "^2.0.3"
+    source-map "^0.6.1"
+    source-map-resolve "^0.5.2"
+    urix "^0.1.0"
 
 cssdb@^4.3.0:
   version "4.4.0"
@@ -5906,7 +5944,7 @@ jest-dev-server@^3.9.0:
     tree-kill "^1.2.1"
     wait-port "^0.2.2"
 
-jest-diff@^24.8.0:
+jest-diff@^24.0.0, jest-diff@^24.8.0:
   version "24.8.0"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-24.8.0.tgz#146435e7d1e3ffdf293d53ff97e193f1d1546172"
   integrity sha512-wxetCEl49zUpJ/bvUmIFjd/o52J+yWcoc5ZyPq4/W1LUKGEhRYDIbP1KcF6t+PvqNrGAFk4/JhtxDq/Nnzs66g==
@@ -5922,6 +5960,20 @@ jest-docblock@^24.3.0:
   integrity sha512-nlANmF9Yq1dufhFlKG9rasfQlrY7wINJbo3q01tu56Jv5eBU5jirylhF2O5ZBnLxzOVBGRDz/9NAwNyBtG4Nyg==
   dependencies:
     detect-newline "^2.1.0"
+
+jest-dom@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/jest-dom/-/jest-dom-3.4.0.tgz#46c21984a73a4841dc57bc8fc09ccd1d971a8447"
+  integrity sha512-fQR5ESaxTfNbZE02y+gtaQH7+sMwzrQtJo5OE0E3BNArjTL9GWNI+uPFr1yS24eodH1X62L+qncv106M/O98gQ==
+  dependencies:
+    chalk "^2.4.1"
+    css "^2.2.3"
+    css.escape "^1.5.1"
+    jest-diff "^24.0.0"
+    jest-matcher-utils "^24.0.0"
+    lodash "^4.17.11"
+    pretty-format "^24.0.0"
+    redent "^2.0.0"
 
 jest-each@^24.8.0:
   version "24.8.0"
@@ -6034,7 +6086,7 @@ jest-leak-detector@^24.8.0:
   dependencies:
     pretty-format "^24.8.0"
 
-jest-matcher-utils@^24.8.0:
+jest-matcher-utils@^24.0.0, jest-matcher-utils@^24.8.0:
   version "24.8.0"
   resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-24.8.0.tgz#2bce42204c9af12bde46f83dc839efe8be832495"
   integrity sha512-lex1yASY51FvUuHgm0GOVj7DCYEouWSlIYmCW7APSqB9v8mXmKSn5+sWVF0MhuASG0bnYY106/49JU1FZNl5hw==
@@ -8712,7 +8764,7 @@ pretty-format@^23.6.0:
     ansi-regex "^3.0.0"
     ansi-styles "^3.2.0"
 
-pretty-format@^24.8.0:
+pretty-format@^24.0.0, pretty-format@^24.8.0:
   version "24.8.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.8.0.tgz#8dae7044f58db7cb8be245383b565a963e3c27f2"
   integrity sha512-P952T7dkrDEplsR+TuY7q3VXDae5Sr7zmQb12JU/NDQa/3CH7/QW0yvqLcGN6jL+zQFKaoJcPc+yJxMTGmosqw==
@@ -9361,6 +9413,14 @@ redent@^1.0.0:
   dependencies:
     indent-string "^2.1.0"
     strip-indent "^1.0.1"
+
+redent@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/redent/-/redent-2.0.0.tgz#c1b2007b42d57eb1389079b3c8333639d5e1ccaa"
+  integrity sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=
+  dependencies:
+    indent-string "^3.0.0"
+    strip-indent "^2.0.0"
 
 reduce-css-calc@^1.3.0:
   version "1.3.0"
@@ -10132,7 +10192,7 @@ source-map-explorer@^1.6.0:
     source-map "^0.5.1"
     temp "^0.9.0"
 
-source-map-resolve@^0.5.0:
+source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.2.tgz#72e2cc34095543e43b2c62b2c4c10d4a9054f259"
   integrity sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==
@@ -10457,6 +10517,11 @@ strip-indent@^1.0.1:
   integrity sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=
   dependencies:
     get-stdin "^4.0.1"
+
+strip-indent@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
+  integrity sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=
 
 strip-json-comments@^2.0.1, strip-json-comments@~2.0.1:
   version "2.0.1"
@@ -11153,6 +11218,11 @@ w3c-xmlserializer@^1.1.2:
     domexception "^1.0.1"
     webidl-conversions "^4.0.2"
     xml-name-validator "^3.0.0"
+
+wait-for-expect@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-1.2.0.tgz#fdab6a26e87d2039101db88bff3d8158e5c3e13f"
+  integrity sha512-EJhKpA+5UHixduMBEGhTFuLuVgQBKWxkFbefOdj2bbk2/OpA5Opsc4aUTGmF+qJ+v3kTGxDRNYwKaT4j6g5n8Q==
 
 wait-port@^0.2.2:
   version "0.2.2"


### PR DESCRIPTION
## Issue Number

#648 

## Purpose/Implementation Notes

Another attempt to fixing `useLoader`. [Found a way](https://overreacted.io/a-complete-guide-to-useeffect/#why-usereducer-is-the-cheat-mode-of-hooks) to remove `state` as a dependency from the effect that called `fetch` so that we can avoid the infinite cycles that caused #648 

## Types of changes

* [x] Bugfix (non-breaking change which fixes an issue)

## Functional tests

Added tests for this.

## Checklist

* [x] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
* [ ] Any dependent changes have been merged and published in downstream modules
