### PR TITLE
refactor useLoader to reduce loops

### DIFF
--- a/src/pages/Dashboard/index.js
+++ b/src/pages/Dashboard/index.js
@@ -11,18 +11,15 @@ import { getQueryParamObject, formatBytes } from '../../common/helpers';
 import './Dashboard.scss';
 
 function Dashboard(props) {
-  const [chartUpdating, setChartUpdating] = React.useState(true);
   let { range: rangeParam } = getQueryParamObject(props.location.search);
   if (!['day', 'week', 'month', 'year'].includes(rangeParam)) {
     rangeParam = 'day';
   }
   const [range, setRange] = React.useState(rangeParam);
-  const fetchCallback = React.useCallback(async () => {
+  const { data, refresh, isLoading, hasError } = useLoader(async () => {
     const stats = await fetchDashboardData(range);
-    setChartUpdating(false);
     return getDashboardChartConfig(stats, range);
   }, [range]);
-  const { data, refresh, hasError } = useLoader(fetchCallback, [range]);
 
   // refresh data every 10 mins
   useInterval(() => {
@@ -44,15 +41,12 @@ function Dashboard(props) {
             { label: 'Last Month', value: 'month' },
             { label: 'Last Year', value: 'year' },
           ]}
-          onChange={range => {
-            setChartUpdating(true);
-            setRange(range);
-          }}
+          onChange={selected => setRange(selected)}
         />
 
         <p>* All dates in UTC</p>
 
-        {!data || chartUpdating ? (
+        {!data || isLoading ? (
           <Spinner />
         ) : (
           data.map(section => {


### PR DESCRIPTION
## Issue Number

#648 

## Purpose/Implementation Notes

I was working on a house cleaning PR implementing some of the new esLint rules when I stumbled across the executive-dashboard doing infinite loops. 👎 So this is a fix for that.

The idea here is that the useLoader should only return it's own state. That state should only be set in the dataFetchReducer. The fetched data should only be called when the watched property changes. Also it should fetch data initially on the first render/page load.

Note:
Occasionally in development mode you might see a console warning if the dashboard was unmounted and the fetch resolves or if an invalidated fetch resolves it would set state and React would warn about a potential memory leak. I believe In the next version of React (16.9.x) there will be better ways of implementing this functionality. Hypothetically, if the days were longer you could implement an AbortController in the return function (the way you cleanup on unmount) of the useEffect inside useLoader. But refactoring that code to make this air tight would take on more risk than reward IMO.

This PR's changes are in two parts.

1. A refactor of useLoader.
 - adds hasError: true/false to the state changes in dataFetchReducer
 - Defines fetchDataCallback at the top of useLoader so it can be set to state
 - adds ...updateProps to the dependencies of the fetchDataCallback and silences eslint warnings
 - removes fetchDataCallback from dependencies of the useEffect
 - returns only the state object

2. Simplifies the pages/dashboard/index
 - adds isLoading to deconstructed useLoader return
 - removes references to updateCharts in favor of isLoading
 - removes the useCallback wrapped fetchCallback due to useLoader refactor 

## Types of changes

* [x] Bugfix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

No infinite loops on dashboard or executive dashboard. 
Tested these events:
- dashboard load
- dashboard range select callback
- dashboard refresh from interval
- executive dashboard
- executive dashboard refresh from interval
- executive dashboard SamplesProcessedBlock load
- executive dashboard SamplesProcessedBlock range select callback

## Checklist

* [x] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
* [ ] Any dependent changes have been merged and published in downstream modules
