### PR TITLE
adds loading state for onClicks that return a promise

### DIFF
--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -136,7 +136,8 @@ $default-active-shadow: 0 3px 4px 0 rgba($black, 0.3);
       color: transparent;
     }
 
-    .button--indicator {
+    &:before {
+      content: '';
       visibility: visible;
       display: inline-block;
       vertical-align: baseline;
@@ -164,7 +165,7 @@ $default-active-shadow: 0 3px 4px 0 rgba($black, 0.3);
 
     &.button--plain,
     &.button--link {
-      .button--indicator {
+      &:before {
         top: auto;
         right: 0;
         animation-name: border-color-change, loading-spin-inline;

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -126,7 +126,86 @@ $default-active-shadow: 0 3px 4px 0 rgba($black, 0.3);
     font-size: 16px;
     padding: 8px 32px;
   }
+
+  &--loading {
+    position: relative;
+    color: transparent;
+    &:hover,
+    &:active,
+    &:focus {
+      color: transparent;
+    }
+
+    .button--indicator {
+      visibility: visible;
+      display: inline-block;
+      vertical-align: baseline;
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      margin: 0;
+      width: 10px;
+      height: 10px;
+      background-color: transparent;
+      border-top: 1px solid transparent;
+      border-right: 1px solid transparent;
+      border-left: 1px solid transparent;
+      border-bottom: 1px solid transparent;
+      border-radius: 50%;
+
+      animation: border-color-change, loading-spin-center;
+      animation-duration: 1.2s;
+      animation-iteration-count: infinite;
+
+      + * {
+        visibility: hidden;
+      }
+    }
+
+    &.button--plain,
+    &.button--link {
+      .button--indicator {
+        top: auto;
+        right: 0;
+        animation-name: border-color-change, loading-spin-inline;
+      }
+    }
+  }
 }
 
 .button__icon {
+}
+
+@keyframes border-color-change {
+  from,
+  to {
+    border-top-color: white;
+    border-right-color: $azure;
+    border-bottom-color: white;
+    border-left-color: $azure;
+  }
+  50% {
+    border-top-color: $azure;
+    border-right-color: white;
+    border-bottom-color: $azure;
+    border-left-color: white;
+  }
+}
+
+@keyframes loading-spin-center {
+  from {
+    transform: translate(-50%, -50%) rotate(0deg);
+  }
+  to {
+    transform: translate(-50%, -50%) rotate(360deg);
+  }
+}
+
+@keyframes loading-spin-inline {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
 }

--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -6,20 +6,49 @@ const Button = ({
   text,
   buttonStyle,
   isDisabled = false,
-  className,
+  className = '',
   children,
   type = 'button',
+  onClick,
   ...props
 }) => {
+  const loadingRef = React.useRef(false);
+  const promiseRef = React.useRef();
+
+  const buttonClick = () => {
+    if (typeof onClick === 'function') {
+      if (loadingRef.current) return promiseRef.curent;
+      const maybePromise = onClick();
+      if (maybePromise && typeof maybePromise.then === 'function') {
+        promiseRef.current = maybePromise;
+        loadingRef.current = true;
+        maybePromise.then(() => {
+          promiseRef.current = undefined;
+          loadingRef.current = false;
+        });
+      }
+      return maybePromise;
+    }
+    return onClick;
+  };
+
+  const { current: isLoading } = loadingRef;
   const buttonStyleClass = buttonStyle ? `button--${buttonStyle}` : '';
   /* eslint-disable react/button-has-type */
   return (
     <button
       {...props}
+      onClick={buttonClick}
       type={type}
-      className={classnames('button', buttonStyleClass, className)}
+      className={classnames({
+        button: true,
+        [buttonStyleClass]: true,
+        [className]: true,
+        'button--loading': isLoading,
+      })}
       disabled={isDisabled}
     >
+      {isLoading && <span className="button--indicator" />}
       {text || children}
     </button>
   );

--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -48,7 +48,6 @@ const Button = ({
       })}
       disabled={isDisabled}
     >
-      {isLoading && <span className="button--indicator" />}
       {text || children}
     </button>
   );

--- a/src/components/HighlightedText.js
+++ b/src/components/HighlightedText.js
@@ -7,11 +7,13 @@ import shortid from 'shortid';
  * @param {highlight} can be a string or an array of string with the text to highlight
  */
 export default function HighlightedText({ text, highlight }) {
-  if (!highlight) return text;
+  const highlightText = Array.isArray(highlight)
+    ? highlight.filter(x => x).join('|')
+    : highlight;
 
-  const highlightRegex = Array.isArray(highlight)
-    ? new RegExp(`(${highlight.join('|')})`, 'gi')
-    : new RegExp(`(${highlight})`, 'gi');
+  if (!highlightText) return text;
+
+  const highlightRegex = new RegExp(`(${highlightText})`, 'gi');
 
   // Split on highlight term and include term into parts, ignore case
   const parts = text

--- a/src/components/HighlightedText.js
+++ b/src/components/HighlightedText.js
@@ -4,17 +4,22 @@ import shortid from 'shortid';
 /**
  * Hightlight portions of a text.
  * thanks to https://stackoverflow.com/a/43235785/763705
+ * @param {highlight} can be a string or an array of string with the text to highlight
  */
 export default function HighlightedText({ text, highlight }) {
   if (!highlight) return text;
 
+  const highlightRegex = Array.isArray(highlight)
+    ? new RegExp(`(${highlight.join('|')})`, 'gi')
+    : new RegExp(`(${highlight})`, 'gi');
+
   // Split on highlight term and include term into parts, ignore case
   const parts = text
-    .split(new RegExp(`(${highlight})`, 'gi'))
+    .split(highlightRegex)
     .map(part => ({ part, id: shortid() }));
 
   return parts.map(({ part, id }) =>
-    part && part.toLowerCase() === highlight.toLowerCase() ? (
+    highlightRegex.test(part) ? (
       <span key={id} className="text-highlight">
         {part}
       </span>

--- a/src/components/HorizontalScroll.scss
+++ b/src/components/HorizontalScroll.scss
@@ -70,11 +70,12 @@
       animation-fill-mode: both;
       animation-name: eva-shake;
       animation-duration: 1s;
+      animation-delay: 1s;
     }
   }
 
   &__disabled {
-    display: none;
+    visibility: hidden;
   }
 }
 

--- a/src/history.js
+++ b/src/history.js
@@ -1,4 +1,4 @@
-import createHistory from 'history/createBrowserHistory';
+import { createBrowserHistory } from 'history';
 import ReactGA from 'react-ga';
 
 // Thanks to https://github.com/fabe/gatsby-universal/issues/4
@@ -21,7 +21,7 @@ const getUserConfirmation = (location, callback) => {
 
 let history;
 if (typeof document !== 'undefined') {
-  history = createHistory({ getUserConfirmation });
+  history = createBrowserHistory({ getUserConfirmation });
 
   // `block` must return a string to conform.
   // We send both the pathname and action to `getUserConfirmation`.

--- a/src/pages/Experiment/index.js
+++ b/src/pages/Experiment/index.js
@@ -161,7 +161,7 @@ let Experiment = ({ match, location: { state }, goBack }) => {
                       />{' '}
                       {organisms.length
                         ? organisms
-                            .map(organism => formatSentenceCase(organism.name))
+                            .map(organism => formatSentenceCase(organism))
                             .join(', ')
                         : 'No species.'}
                     </div>

--- a/src/pages/Experiment/index.js
+++ b/src/pages/Experiment/index.js
@@ -77,10 +77,9 @@ let Experiment = ({ match, location: { state }, goBack }) => {
           let displaySpinner = isLoading;
           let experimentData = experiment || { samples: [] };
           let totalSamples = experimentData.samples.length;
-          const totalProcessedSamples = experimentData.samples.filter(
-            x => x.is_processed
-          ).length;
-          let { organisms } = experimentData;
+          const numDownloadableSamples =
+            experimentData['num_downloadable_samples'];
+          let organisms = experimentData.organism_names;
 
           // for users coming from the search, see if there's any experiment's data in the url state
           if (isLoading && comesFromSearch && state.result) {
@@ -136,7 +135,7 @@ let Experiment = ({ match, location: { state }, goBack }) => {
                       <HText>{experimentData.title || 'No Title.'}</HText>
                     </h1>
                     <div>
-                      {totalProcessedSamples === 0 ? (
+                      {numDownloadableSamples === 0 ? (
                         <RequestExperimentButton
                           accessionCode={accessionCode}
                         />
@@ -145,7 +144,7 @@ let Experiment = ({ match, location: { state }, goBack }) => {
                           dataSetSlice={{
                             [experimentData.accession_code]: {
                               all: true,
-                              total: totalProcessedSamples,
+                              total: numDownloadableSamples,
                             },
                           }}
                         />
@@ -172,7 +171,7 @@ let Experiment = ({ match, location: { state }, goBack }) => {
                         className="experiment__stats-icon"
                         alt="Sample Icon"
                       />{' '}
-                      <NDownloadableSamples total={totalProcessedSamples} />
+                      <NDownloadableSamples total={numDownloadableSamples} />
                     </div>
 
                     <div

--- a/src/pages/Search/Result/index.js
+++ b/src/pages/Search/Result/index.js
@@ -59,14 +59,14 @@ const Result = ({ result, query }) => {
           </Link>
         </div>
 
-        {result.num_processed_samples === 0 ? (
+        {result.num_downloadable_samples === 0 ? (
           <RequestExperimentButton accessionCode={result.accession_code} />
         ) : (
           <DataSetSampleActions
             dataSetSlice={{
               [result.accession_code]: {
                 all: true,
-                total: result.num_processed_samples,
+                total: result.num_downloadable_samples,
               },
             }}
           />
@@ -87,7 +87,7 @@ const Result = ({ result, query }) => {
         </li>
         <li className="result__stat">
           <img src={SampleIcon} className="result__icon" alt="sample-icon" />{' '}
-          <NDownloadableSamples total={result.num_processed_samples} />
+          <NDownloadableSamples total={result.num_downloadable_samples} />
         </li>
         <li className="result__stat">
           <TechnologyBadge

--- a/src/pages/Search/index.js
+++ b/src/pages/Search/index.js
@@ -26,9 +26,9 @@ import {
   triggerSearch,
   clearFilters,
   updateResultsPerPage,
+  getAccessionCodes,
 } from '../../state/search/actions';
 import Spinner from '../../components/Spinner';
-
 import InfoBox from '../../components/InfoBox';
 import { searchUrl } from '../../routes';
 import './SearchResults.scss';
@@ -45,7 +45,7 @@ class SearchResults extends Component {
   constructor(props) {
     super(props);
 
-    const searchArgs = this._parseUrl();
+    const searchArgs = this.parseUrl();
     this.state = {
       query: searchArgs.query,
       filters: searchArgs.filters,
@@ -56,7 +56,7 @@ class SearchResults extends Component {
    * Reads the search query and other parameters from the url and submits a new request to update the results.
    */
   async updateResults() {
-    const searchArgs = this._parseUrl();
+    const searchArgs = this.parseUrl();
 
     this.setState({
       query: searchArgs.query,
@@ -65,7 +65,7 @@ class SearchResults extends Component {
 
     // check if the search term and the filters are the same, in which case we don't need to
     // fetch the results again
-    if (this._resultsAreFetched()) {
+    if (this.resultsAreFetched()) {
       return;
     }
 
@@ -74,8 +74,8 @@ class SearchResults extends Component {
     await this.props.fetchResults(searchArgs);
   }
 
-  _resultsAreFetched() {
-    const searchArgs = this._parseUrl();
+  resultsAreFetched() {
+    const searchArgs = this.parseUrl();
 
     return (
       this.props.results &&
@@ -86,6 +86,36 @@ class SearchResults extends Component {
       searchArgs.page === this.props.pagination.currentPage &&
       searchArgs.size === this.props.pagination.resultsPerPage
     );
+  }
+
+  parseUrl() {
+    /* eslint-disable prefer-const */
+    let {
+      q: query,
+      p: page = 1,
+      size = 10,
+      ordering = '',
+      filter_order = '',
+      ...filters
+    } = getQueryParamObject(this.props.location.search);
+    /* eslint-enable */
+
+    // for consistency, ensure all values in filters are arrays
+    // the method `getQueryParamObject` will return a single value for parameters that only
+    // appear once in the url
+    for (const key of Object.keys(filters)) {
+      if (!Array.isArray(filters[key])) {
+        filters[key] = [filters[key]];
+      }
+    }
+
+    // parse parameters from url
+    query = query ? decodeURIComponent(query) : undefined;
+    page = parseInt(page, 10);
+    size = parseInt(size, 10);
+    const filterOrder = filter_order ? filter_order.split(',') : [];
+
+    return { query, page, size, ordering, filters, filterOrder };
   }
 
   render() {
@@ -126,19 +156,26 @@ class SearchResults extends Component {
             updateProps={this.props.location.search}
             fetch={() => this.updateResults()}
           >
-            {({ isLoading, hasError }) =>
-              isLoading && !this._resultsAreFetched() ? (
-                <Spinner />
-              ) : hasError ? (
-                <ErrorApiUnderHeavyLoad />
-              ) : !results.length && !anyFilterApplied(this.state.filters) ? (
-                <NoSearchResults query={this.state.query} />
-              ) : !results.length ? (
-                <NoSearchResultsTooManyFilters
-                  query={this.state.query}
-                  appliedFilters={this.state.filters}
-                />
-              ) : (
+            {({ isLoading, hasError }) => {
+              if (isLoading && !this.resultsAreFetched()) {
+                return <Spinner />;
+              }
+              if (hasError) {
+                return <ErrorApiUnderHeavyLoad />;
+              }
+              if (!results.length && !anyFilterApplied(this.state.filters)) {
+                return <NoSearchResults query={this.state.query} />;
+              }
+              if (!results.length) {
+                return (
+                  <NoSearchResultsTooManyFilters
+                    query={this.state.query}
+                    appliedFilters={this.state.filters}
+                  />
+                );
+              }
+
+              return (
                 <div className="results__container">
                   <div className="results__top-bar">
                     <div className="results__number-results">
@@ -154,7 +191,12 @@ class SearchResults extends Component {
                     appliedFilters={this.state.filters}
                   />
                   <div className="results__list">
-                    <Hightlight match={this.state.query}>
+                    <Hightlight
+                      match={[
+                        this.state.query,
+                        ...getAccessionCodes(this.state.query),
+                      ]}
+                    >
                       {results.map((result, index) => (
                         <React.Fragment key={result.accession_code}>
                           <Result result={result} query={this.state.query} />
@@ -184,42 +226,12 @@ class SearchResults extends Component {
                     />
                   </div>
                 </div>
-              )
-            }
+              );
+            }}
           </Loader>
         </div>
       </div>
     );
-  }
-
-  _parseUrl() {
-    /* eslint-disable prefer-const */
-    let {
-      q: query,
-      p: page = 1,
-      size = 10,
-      ordering = '',
-      filter_order = '',
-      ...filters
-    } = getQueryParamObject(this.props.location.search);
-    /* eslint-enable */
-
-    // for consistency, ensure all values in filters are arrays
-    // the method `getQueryParamObject` will return a single value for parameters that only
-    // appear once in the url
-    for (const key of Object.keys(filters)) {
-      if (!Array.isArray(filters[key])) {
-        filters[key] = [filters[key]];
-      }
-    }
-
-    // parse parameters from url
-    query = query ? decodeURIComponent(query) : undefined;
-    page = parseInt(page, 10);
-    size = parseInt(size, 10);
-    const filterOrder = filter_order ? filter_order.split(',') : [];
-
-    return { query, page, size, ordering, filters, filterOrder };
   }
 }
 SearchResults = connect(

--- a/src/pages/Search/index.js
+++ b/src/pages/Search/index.js
@@ -248,7 +248,7 @@ function AddPageToDataSetButton({ results }) {
   const resultsDataSetSlice = fromPairs(
     results.map(result => [
       result.accession_code,
-      { all: true, total: result.num_processed_samples },
+      { all: true, total: result.num_downloadable_samples },
     ])
   );
 

--- a/src/pages/SpeciesCompendia/index.js
+++ b/src/pages/SpeciesCompendia/index.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import Helmet from 'react-helmet';
-import Button from '../../components/Button';
 import './SpeciesCompendia.scss';
 import EmailSection from '../Main/EmailSection';
 import PointsBackground from './PointsBackground';
@@ -84,7 +83,14 @@ export default function SpeciesCompendia() {
               quantile normalization.
             </div>
 
-            <Button text="Learn More" buttonStyle="secondary" />
+            <a
+              href="http://docs.refine.bio/en/latest/main_text.html#species-compendia"
+              className="button button--secondary"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Learn More
+            </a>
           </div>
         </div>
       </div>

--- a/src/state/search/actions.js
+++ b/src/state/search/actions.js
@@ -1,4 +1,5 @@
 import pickBy from 'lodash/pickBy';
+import uniqBy from 'lodash/uniqBy';
 import { push } from '../routerActions';
 import { getQueryString, Ajax } from '../../common/helpers';
 import reportError from '../reportError';
@@ -43,9 +44,16 @@ const navigateToResults = ({
   });
 };
 
-function isAccessionCode(accessionCode) {
-  if (!accessionCode) return false;
-  return /^(GSE|ERP|SRP)(\d{3,6}$)|(E-[A-Z]{4}-\d{2,4}$)/i.test(accessionCode);
+const ACCESSION_CODE_REGEX = /^(GSE|ERP|SRP)(\d{3,6}$)|(E-[A-Z]{4}-\d{2,4}$)/i;
+
+/**
+ * Returns an array with all the accession codes in the search query (if any)
+ * @param {string} query search query
+ */
+export function getAccessionCodes(query) {
+  if (!query) return [];
+  const accessionCodes = query.split(/,| /i);
+  return accessionCodes.filter(code => ACCESSION_CODE_REGEX.test(code));
 }
 
 export function fetchResults({
@@ -68,25 +76,30 @@ export function fetchResults({
       let { results } = apiResults;
       const { count: totalResults, facets } = apiResults;
 
+      const accessionCodes = getAccessionCodes(query);
+
       // do accession code search
-      if (isAccessionCode(query) && page === 1) {
-        const { results: topResults } = await Ajax.get('/es/', {
-          search: `accession_code:${query}`,
-        });
-
-        // mark top results
-        topResults.forEach(experiment => {
-          experiment._isTopResult = true;
-        });
-
-        // filter out top results
-        results = results.filter(x =>
-          topResults.some(
-            topExperiment => x.accession_code !== topExperiment.accession_code
+      if (accessionCodes.length > 0 && page === 1) {
+        // each accession code requires an specific query to fetch the exact experiment
+        const promises = await Promise.all(
+          accessionCodes.map(code =>
+            Ajax.get('/es/', {
+              search: `accession_code:${code}`,
+            })
           )
         );
+        const topResults = []
+          .concat(...promises.map(data => data.results))
+          .map(result => ({
+            ...result,
+            // this is a hack to mark the results that should be displayed in the top region
+            // these are usually from accession code search
+            _isTopResult: true,
+          }));
 
-        results = [...topResults, ...results];
+        // since we made multiple queries to the server, make sure that there are
+        // no repeated experiments.
+        results = uniqBy([...topResults, ...results], x => x.accession_code);
       }
 
       let filters = transformFacets(facets);

--- a/src/state/search/actions.js
+++ b/src/state/search/actions.js
@@ -8,8 +8,8 @@ export const MOST_SAMPLES = 'MostSamples';
 
 export const Ordering = {
   BestMatch: '_score',
-  MostSamples: '-num_processed_samples',
-  LeastSamples: 'num_processed_samples',
+  MostSamples: '-num_downloadable_samples',
+  LeastSamples: 'num_downloadable_samples',
   Newest: '-source_first_published',
   Oldest: 'source_first_published',
 };

--- a/src/state/search/actions.test.js
+++ b/src/state/search/actions.test.js
@@ -85,10 +85,10 @@ describe('fetching a dataset', () => {
   it('pass ordering parameter', async () => {
     const store = mockStore();
     await store.dispatch(
-      fetchResults({ query: 'cancer', ordering: 'num_processed_samples' })
+      fetchResults({ query: 'cancer', ordering: 'num_downloadable_samples' })
     );
     expect(global.fetch.mock.calls[0]).toEqual([
-      '/es/?search=cancer&limit=10&offset=0&ordering=num_processed_samples',
+      '/es/?search=cancer&limit=10&offset=0&ordering=num_downloadable_samples',
     ]);
   });
 });


### PR DESCRIPTION
## Issue Number

#613 

## Purpose/Implementation Notes

Sometimes on slow connections async calls take more than a beat to complete. This PR adds a wrapper method to a ```Button``` component's ```onClick``` property that checks if the passed in function returns a promise. If it doesn't or it's not a function it's business as usual. But if it does return a promise the button will display a little spinner and hide the contents of the button. It uses ```visibility:hidden``` and ```color: transparent``` in the button to keep it's layout the same during the loading state.

Additionally,
I made the assumption that multiple clicks should be handled after the previous click has been returned so it's essentially disabled during the load state. This should be confirmed as there might be a place in the app now or in the future where this assumption is wrong.

Also this is currently opt-in by default but could be made opt-out by default too.

One last thing. Maybe on error there should be a shake event to communicate that something went wrong? 

## Types of changes

What types of changes does your code introduce?

* [ ] Bugfix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

I click a bunch of buttons that return promises(like adding or removing something from your dataset) and ones that don't (like showing a modal or the scroll back to top button).

## Checklist

* [x] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
* [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

![2019-06-22 17 58 55](https://user-images.githubusercontent.com/1075609/59969401-7a984a80-951a-11e9-9769-399b3a86c9de.gif)
![2019-06-22 17 59 13](https://user-images.githubusercontent.com/1075609/59969402-7f5cfe80-951a-11e9-9f79-7e82e3295c46.gif)

