### PR TITLE
Queued Actions Middleware

### DIFF
--- a/src/state/download/actions.js
+++ b/src/state/download/actions.js
@@ -102,23 +102,25 @@ const dataSetUpdateOperation = (modifier, details = false) => async (
  * @param {object} dataSetSlice
  */
 export const addSamples = dataSetSlice => async dispatch =>
-  dispatch(
-    dataSetUpdateOperation(dataSet =>
+  dispatch({
+    queueChannel: 'dataSetUpdateOperation',
+    queuedAction: dataSetUpdateOperation(dataSet =>
       new DataSetManager(dataSet).add(dataSetSlice)
-    )
-  );
+    ),
+  });
 
 /**
  * Removes all experiments with the corresponding accession codes from dataset
  * @param {array} accessionCodes
  */
 export const removeExperiment = (accessionCodes, details = false) => dispatch =>
-  dispatch(
-    dataSetUpdateOperation(
+  dispatch({
+    queueChannel: 'dataSetUpdateOperation',
+    queuedAction: dataSetUpdateOperation(
       dataSet => new DataSetManager(dataSet).removeExperiment(accessionCodes),
       details
-    )
-  );
+    ),
+  });
 
 /**
  * Removes all samples with corresponding ids from each experiment in dataset.
@@ -128,12 +130,13 @@ export const removeSamples = (
   dataSetSlice,
   details = false
 ) => async dispatch =>
-  dispatch(
-    dataSetUpdateOperation(
+  dispatch({
+    queueChannel: 'dataSetUpdateOperation',
+    queuedAction: dataSetUpdateOperation(
       dataSet => new DataSetManager(dataSet).remove(dataSetSlice),
       details
-    )
-  );
+    ),
+  });
 
 /**
  * Use the dataset from the state
@@ -185,7 +188,10 @@ export const fetchDataSet = (details = false) => async (dispatch, getState) => {
 
 // Remove all dataset
 export const clearDataSet = () => dispatch =>
-  dispatch(dataSetUpdateOperation(dataSet => ({})));
+  dispatch({
+    queueChannel: 'dataSetUpdateOperation',
+    queuedAction: dataSetUpdateOperation(dataSet => ({})),
+  });
 
 /**
  * Gets detailed information about the samples and experiments associated with

--- a/src/store/queueMiddleware.js
+++ b/src/store/queueMiddleware.js
@@ -1,0 +1,49 @@
+/**
+ * This middleware allows for dispatched actions to be called successively, FIFO.
+ * Use by passing and action of type {queuedAction: func, queueChannel: 'CHANNEL_NAME_ACTION_TYPE'})
+ * The action passe will be defered until
+ */
+
+const queueMiddleware = ({ dispatch, getState }) => {
+  const queues = {};
+  return next => async action => {
+    const { queuedAction, queueChannel } = action;
+    const isFunction = typeof queuedAction === 'function';
+    const isObject = typeof queuedAction === 'object';
+    const isQueueChannel = typeof queueChannel === 'string';
+    const didQueue = (isFunction || isObject) && isQueueChannel;
+
+    if (!didQueue) return next(action);
+
+    const queue = Array.isArray(queues[queueChannel])
+      ? queues[queueChannel]
+      : (queues[queueChannel] = []);
+
+    const promise = new Promise(async (resolve, reject) => {
+      const resolveQueuedAction = async () => {
+        if (typeof queuedAction === 'function') {
+          try {
+            const result = await queuedAction(dispatch, getState);
+            return resolve(result);
+          } catch (e) {
+            return reject(e);
+          }
+        }
+        // wasnt a function?
+        return resolve(() => next(queuedAction));
+      };
+      // resolve now if queue is empty
+      if (queue.length === 0) return resolveQueuedAction();
+      // resolve when last promise in stack resolves
+      return queue[queue.length - 1].then(resolveQueuedAction);
+    });
+    // enqueue
+    queue.push(promise);
+    // dequeue
+    promise.then(() => queue.shift());
+
+    return promise;
+  };
+};
+
+export default queueMiddleware;

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -8,6 +8,7 @@ import history from '../history';
 import { CALL_HISTORY_METHOD } from '../state/routerActions';
 import { REPORT_ERROR } from '../state/reportError';
 import progressMiddleware from './progressMiddleware';
+import queueMiddleware from './queueMiddleware';
 import { ApiVersionMismatchError } from '../common/errors';
 
 const initialState = loadInitialState();
@@ -63,7 +64,8 @@ const store = createStore(
       thunk,
       routerMiddleware(history),
       errorMiddleware,
-      persistMiddleware
+      persistMiddleware,
+      queueMiddleware
     )
   )
 );


### PR DESCRIPTION
## Issue Number

Waiting on adressing #613
## Purpose/Implementation Notes

This adds middleware ```src/store/queueMiddleware.js``` for queueing requests, specifically to benefit the experience on slower connections that have to wait longer for the asynchronous updates to the dataset which overrides previous (and still in the process of being executed) requests - such as adding a couple samples to your dataset. (Reference the attached screenshots.)

Apart from adding the middleware itself, it applies changes to ```state/download/actions.js``` to implement the new middleware. Such as: 

```javascript

/**
 * Takes an array of experiment objects and adds to users dataset via endpoint
 * @param {object} dataSetSlice
 */
export const addSamples = dataSetSlice => async dispatch =>
  dispatch({
    queueChannel: 'dataSetUpdateOperation',
    queuedAction: dataSetUpdateOperation(dataSet =>
      new DataSetManager(dataSet).add(dataSetSlice)
    ),
  });
```

## Types of changes

* [ ] Bugfix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

This helps to test if you open developer tools in chrome -> options -> more tools -> network conditions -> and test with either ```Fast 3G``` or ```Slow 3G```. It still occurs on fast connections if you click around quickly but throttling your connect makes it considerably easier to replicate. I mean it's a race condition so it's naturally unpredictable. 

## Checklist

* [x] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
* [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots
Original:
![2019-06-24 12 46 06](https://user-images.githubusercontent.com/1075609/60061354-d8679680-96c2-11e9-9f43-a82fd2bc9ff1.gif)

With Queues:
![2019-06-24 13 00 50](https://user-images.githubusercontent.com/1075609/60061381-f46b3800-96c2-11e9-8531-baa724149f72.gif)

