### PR TITLE
horizontal scroll but quieter

### DIFF
--- a/src/components/HorizontalScroll.scss
+++ b/src/components/HorizontalScroll.scss
@@ -70,6 +70,7 @@
       animation-fill-mode: both;
       animation-name: eva-shake;
       animation-duration: 1s;
+      animation-delay: 1s;
     }
   }
 

--- a/src/components/HorizontalScroll.scss
+++ b/src/components/HorizontalScroll.scss
@@ -75,7 +75,7 @@
   }
 
   &__disabled {
-    display: none;
+    visibility: hidden;
   }
 }
 


### PR DESCRIPTION
## Issue Number

#613 

## Purpose/Implementation Notes

Adds 1s delay to button animation.
Prevents Horizontal Scroll Right Button animation from being repeated after horizontal scrolls.

## Types of changes

* [x] Bugfix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

Investigated on experiment and dataset pages.

## Checklist

* [x] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
* [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

![2019-07-01 17 54 20](https://user-images.githubusercontent.com/1075609/60469004-5975df00-9c29-11e9-84f7-e291f2e1f320.gif)

