### PR TITLE
dataSetId is id

### DIFF
--- a/src/state/download/actions.js
+++ b/src/state/download/actions.js
@@ -26,7 +26,7 @@ export const updateDownloadDataSet = data => ({
   type: 'DOWNLOAD_DATASET_UPDATE',
   data,
   persist: {
-    dataSetId: data.dataSetId,
+    dataSetId: data.dataSetId || data.id,
   },
 });
 


### PR DESCRIPTION
## Issue Number

#691 

## Purpose/Implementation Notes

Adds ```|| data.id``` incase the passed in object's id for dataset isn't ```dataSetId``` in the download actions reducer.

## Types of changes

* [x] Bugfix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

List out the functional tests you've completed to verify your changes work locally.

## Checklist

_Put an `x` in the boxes that apply._

* [ ] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
* [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

![2019-07-12 13 42 59](https://user-images.githubusercontent.com/1075609/61147721-10d0e800-a4ab-11e9-9b56-61fe8d29baf5.gif)

