### PR TITLE
pass dataSetId to updateDownloadDataSet dispatch

### DIFF
--- a/src/state/download/actions.js
+++ b/src/state/download/actions.js
@@ -203,6 +203,7 @@ export const fetchDataSetDetails = dataSetId => async (dispatch, getState) => {
   dispatch(
     updateDownloadDataSet({
       ...response,
+      dataSetId,
       dataSet: response.data,
     })
   );
@@ -231,6 +232,7 @@ export const editDataSet = ({ dataSetId, ...params }) => async (
 
   dispatch(
     updateDownloadDataSet({
+      dataSetId,
       dataSet: data,
       is_processing,
       is_processed,

--- a/src/state/download/actions.js
+++ b/src/state/download/actions.js
@@ -26,7 +26,7 @@ export const updateDownloadDataSet = data => ({
   type: 'DOWNLOAD_DATASET_UPDATE',
   data,
   persist: {
-    dataSetId: data.dataSetId || data.id,
+    dataSetId: data.dataSetId,
   },
 });
 
@@ -171,6 +171,7 @@ export const fetchDataSet = (details = false) => async (dispatch, getState) => {
     dispatch(
       updateDownloadDataSet({
         ...data,
+        dataSetId: data.id,
         dataSet: data.data,
       })
     );


### PR DESCRIPTION
## Issue Number

#691 

## Purpose/Implementation Notes

Ensures that ```dataSetId``` is passed to be persisted after the initial fetch from a refreshed page when appropriate.

## Types of changes

* [x] Bugfix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

Tested most if not all dataset changes from user events and refreshes.

## Checklist

* [x] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
* [ ] Any dependent changes have been merged and published in downstream modules
