### PR TITLE
Changed logic for pageSizes to include one larger than the number of samples

### DIFF
--- a/src/components/SamplesTable/SamplesTable.js
+++ b/src/components/SamplesTable/SamplesTable.js
@@ -24,11 +24,9 @@ import { formatSentenceCase } from '../../common/helpers';
 import apiData from '../../apiData.json';
 import { Hightlight, HText } from '../HighlightedText';
 
+// https://github.com/AlexsLemonade/refinebio-frontend/issues/698
+// Collect all the sizes smaller than totalSamples plus the first size larger if it exists
 function getPageSizesFor(totalSamples) {
-  if (totalSamples < 10) return [totalSamples];
-
-  // https://github.com/AlexsLemonade/refinebio-frontend/issues/698
-  // Collect all the sizes smaller than totalSamples plus the first size larger if it exists
   const sizes = [];
   for (const size of PAGE_SIZES) {
     sizes.push(size);

--- a/src/components/SamplesTable/SamplesTable.js
+++ b/src/components/SamplesTable/SamplesTable.js
@@ -24,6 +24,20 @@ import { formatSentenceCase } from '../../common/helpers';
 import apiData from '../../apiData.json';
 import { Hightlight, HText } from '../HighlightedText';
 
+function getPageSizesFor(totalSamples) {
+  if (totalSamples < 10) return [totalSamples];
+
+  // https://github.com/AlexsLemonade/refinebio-frontend/issues/698
+  // Collect all the sizes smaller than totalSamples plus the first size larger if it exists
+  const sizes = [];
+  for (const size of PAGE_SIZES) {
+    sizes.push(size);
+
+    if (size >= totalSamples) break;
+  }
+  return sizes;
+}
+
 class SamplesTable extends React.Component {
   static defaultProps = {
     pageSizeDropdown: ({ dropdown, totalSamples }) => (
@@ -47,10 +61,7 @@ class SamplesTable extends React.Component {
       <SampleDetailsLoader fetchSampleParams={this.props.fetchSampleParams}>
         {state => {
           // Calculate page size options to exclude ones greater than the number of samples.
-          const pageSizes =
-            state.totalSamples < 10
-              ? [state.totalSamples]
-              : PAGE_SIZES.filter(size => size <= state.totalSamples);
+          const pageSizes = getPageSizesFor(state.totalSamples);
 
           return (
             <RefineTable


### PR DESCRIPTION
## Issue Number

Fixes #698

## Purpose/Implementation Notes

I extracted the `pageSizes` logic to a separate function, and adjusted the code to include one size larger than the number of samples if there is a larger size in `PAGE_SIZES`

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

* [x] Bugfix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests
I ran the frontend locally.

## Checklist

_Put an `x` in the boxes that apply._

* [ ] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
* [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

![2019-07-16-15:39:37-screenshot](https://user-images.githubusercontent.com/13942258/61324248-f9ae3500-a7df-11e9-8e40-0b6facadb667.png)

