### PR TITLE
Only report errors to sentry when running on prod domains

### DIFF
--- a/src/store/store.js
+++ b/src/store/store.js
@@ -24,12 +24,12 @@ const errorMiddleware = () => next => action => {
     window.location.reload();
   }
 
-  if (process.env.NODE_ENV === 'development') {
-    // log exception in console on development
-    console.error(error);
-  } else {
+  if (isProduction()) {
     // on Production Report error https://docs.sentry.io/error-reporting/capturing/?platform=browsernpm
     Sentry.captureException(error);
+  } else {
+    // log exception in console on development
+    console.error(error);
   }
 
   return next(action);
@@ -121,4 +121,14 @@ function loadInitialState() {
     },
     token: localStorage.getItem('token'),
   };
+}
+
+/**
+ * Returns true if the app is running on www.refine.bio or staging.refine.bio
+ */
+function isProduction() {
+  return (
+    process.env.NODE_ENV === 'production' &&
+    ['staging.refine.bio', 'www.refine.bio'].includes(window.location.host)
+  );
 }


### PR DESCRIPTION
## Issue Number

close #641 

## Purpose/Implementation Notes

This addresses the problem that motivated #641, although it doesn't hide the key from the code.

It makes sure that errors are only reported when the app is deployed on our domains: www.refine.bio and staging.refine.bio

## Types of changes

* [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

List out the functional tests you've completed to verify your changes work locally.

## Checklist

* [x] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
* [x] Any dependent changes have been merged and published in downstream modules
