### PR TITLE
Generate Sitemaps on Deploy: The Saga of SEO

### DIFF
--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -21,8 +21,10 @@ branch=$(get_master_or_dev)
 
 if [[ $branch == "master" ]]; then
     base_host="refine.bio"
+    host_name="https://www.refine.bio"
 elif [[ $branch == "dev" ]]; then
     base_host="staging.refine.bio"
+    host_name="https://staging.refine.bio"
 else
     echo "Why in the world was update_docker_img.sh called from a branch other than dev or master?!?!?"
     exit 1
@@ -35,6 +37,8 @@ yarn install --ignore-engines
 VERSION=$(git describe --abbrev=0 --tags)
 
 VERSION=$VERSION REACT_APP_API_HOST=https://api.$base_host yarn run cacheBackend
+
+HOST_NAME=$host_name REACT_APP_API_HOST=https://api.$base_host yarn run buildSitemap
 
 CI=false REACT_APP_API_HOST=https://api.$base_host yarn run build
 

--- a/cacheBackend.js
+++ b/cacheBackend.js
@@ -7,7 +7,6 @@
 const axios = require('axios');
 const fs = require('fs');
 const _ = require('lodash');
-const slugify = require('./src/common/slugify');
 
 const version = process.env.VERSION || '0.0.0';
 const ApiVersion = 'v1';

--- a/cacheBackend.js
+++ b/cacheBackend.js
@@ -6,16 +6,15 @@
 
 const axios = require('axios');
 const fs = require('fs');
-const sm = require('sitemap');
 const _ = require('lodash');
 const slugify = require('./src/common/slugify');
 
 const version = process.env.VERSION || '0.0.0';
-const ApiHost = process.env.REACT_APP_API_HOST || 'https://api.refine.bio';
+const ApiVersion = 'v1';
+const ApiHost = `${process.env.REACT_APP_API_HOST || 'https://api.refine.bio'}/${ApiVersion}`;
 
 // Call scripts at deploy time
 cacheServerData();
-generateSitemap();
 
 async function cacheServerData() {
   console.log(`Fetching data to be cached from endpoint: ${ApiHost}`);
@@ -39,54 +38,6 @@ async function cacheServerData() {
     platforms,
   };
   fs.writeFileSync(`src/apiData.json`, JSON.stringify(cache));
-}
-
-/**
- * Generates a sitemap by querying the API to get all experiments accession codes
- */
-async function generateSitemap() {
-  console.log('Building sitemap...');
-  // number of experiments retrieved on each request
-  const limit = 500;
-  const sitemap = sm.createSitemap({
-    hostname: 'https://www.refine.bio',
-    cacheTime: 600000,
-    urls: [
-      { url: '/about', priority: 0.5 },
-      { url: '/license', priority: 0.5 },
-      { url: '/privacy', priority: 0.5 },
-      { url: '/terms', priority: 0.5 },
-    ],
-  });
-
-  // get the total number of experiments
-  const {
-    data: { count },
-  } = await axios.get(`${ApiHost}/search/?limit=${0}`);
-
-  const pageOffsets = _.range(0, count, limit);
-  const experimentPages = await Promise.all(
-    pageOffsets.map(offset =>
-      axios
-        .get(`${ApiHost}/search/?limit=${limit}&offset=${offset}`)
-        .then(request => request.data.results)
-        .catch(ignore => [])
-    )
-  );
-
-  for (const results of experimentPages) {
-    for (const experiment of results) {
-      sitemap.add({
-        url: `/experiments/${experiment.accession_code}/${slugify(
-          experiment.title
-        )}`,
-        priority: 0.8,
-      });
-    }
-  }
-
-  console.log(`Sitemap generated. ${count} experiments found.`);
-  fs.writeFileSync('./public/sitemap.xml', sitemap.toString());
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "prettier": "^1.11.1",
     "puppeteer": "^1.11.0",
     "redux-mock-store": "^1.5.1",
-    "sitemap": "^2.1.0",
+    "sitemap": "^4.1.1",
     "source-map-explorer": "^1.6.0"
   },
   "proxy": "http://localhost:8000/",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "flow": "flow",
     "eslint": "eslint src/",
     "cacheBackend": "node cacheBackend.js",
+    "buildSitemap": "node sitemap.js",
     "test:integration": "jest --runInBand -c integration/jest.config.js"
   },
   "devDependencies": {

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -2,4 +2,4 @@ User-agent: *
 Allow: /
 Disallow: /download
 Disallow: /dataset/*
-Sitemap: https://www.refine.bio/sitemap.xml
+Sitemap: https://www.refine.bio/sitemap-index.xml

--- a/sitemap.js
+++ b/sitemap.js
@@ -1,0 +1,79 @@
+const axios = require('axios');
+const fs = require('fs');
+const { createSitemapIndex } = require('sitemap');
+const slugify = require('./src/common/slugify');
+
+const hostName = process.env.HOST_NAME || 'https://refine.bio';
+const targetFolder = `${__dirname}/public`;
+
+const ApiVersion = process.env.REACT_APP_API_VERSION || 'v1';
+const ApiHost = process.env.REACT_APP_API_HOST || 'https://api.refine.bio';
+const Api = `${ApiHost}/${ApiVersion}`;
+const limit = 1000;
+
+const resourceUrls = {
+  experiments: `${Api}/search/?limit=${limit}&ordering=id`,
+ // samples: `${Api}/samples?limit=${limit}&ordering=id`,
+};
+
+/**
+*Generates a sitemap by querying the API to get all experiments accession codes
+*/
+
+const getSitemapUrlForResource = (resource) => 
+  (result) => {
+    switch (resource) {
+      case 'experiments':
+        const { accession_code: code } = result;
+        const title = slugify(result.title);
+        return {
+          url: `/${resource}/${code}/${title}`,
+          priority: 0.8,
+        }
+    }
+  }
+
+const getUrlsForResources = async (...resources) => {
+  const urls = [];
+  for (const resource of resources) {
+    const getUrl = getSitemapUrlForResource(resource);
+    let next = resourceUrls[resource];
+    while (next) {
+      try {
+        console.log(`Fetching ${resource} from ${next}`);
+        const resp = await axios.get(next);
+        next = resp.data.next;
+        urls.push(...resp.data.results.map(getUrl));
+      } catch (e) {
+        console.log(`Encountered error ${e}`);
+        next = null;
+      } 
+    }  
+  }
+  return urls;
+}
+
+const generateSitemap = async (resources) => {
+  
+  console.log('Building Site Sitemap...');
+
+  const resourceUrls = await getUrlsForResources('experiments');
+  const staticUrls = ['/about', '/license', '/privacy', '/terms'].map(
+    url => ({ url, priority: 0.5 })
+  );
+  const urls = [...staticUrls, ...resourceUrls];
+
+  console.log(`Generating sitemap index and sitemaps for ${urls.length} urls...`); 
+  createSitemapIndex({
+    urls,
+    targetFolder, 
+    hostname,
+    cacheTime: 60000,
+    sitemapName: 'sitemap',
+    sitemapSize: 50000, 
+    xslUrl: '',
+    gzip: false,
+    callback: null,
+  }); 
+}
+generateSitemap();

--- a/sitemap.js
+++ b/sitemap.js
@@ -3,16 +3,16 @@ const fs = require('fs');
 const { createSitemapIndex } = require('sitemap');
 const slugify = require('./src/common/slugify');
 
-const hostName = process.env.HOST_NAME || 'https://refine.bio';
+const hostname = process.env.HOST_NAME || 'https://refine.bio';
 const targetFolder = `${__dirname}/public`;
 
-const ApiVersion = process.env.REACT_APP_API_VERSION || 'v1';
-const ApiHost = process.env.REACT_APP_API_HOST || 'https://api.refine.bio';
-const Api = `${ApiHost}/${ApiVersion}`;
+const ApiVersion = 'v1';
+const ApiHost = `${process.env.REACT_APP_API_HOST || 'https://api.refine.bio'}/${ApiVersion}`;
+
 const limit = 1000;
 
-const resourceUrls = {
-  experiments: `${Api}/search/?limit=${limit}&ordering=id`,
+const resourceEndpoints = {
+  experiments: `${ApiHost}/search/?limit=${limit}&ordering=id`,
  // samples: `${Api}/samples?limit=${limit}&ordering=id`,
 };
 
@@ -37,7 +37,7 @@ const getUrlsForResources = async (...resources) => {
   const urls = [];
   for (const resource of resources) {
     const getUrl = getSitemapUrlForResource(resource);
-    let next = resourceUrls[resource];
+    let next = resourceEndpoints[resource];
     while (next) {
       try {
         console.log(`Fetching ${resource} from ${next}`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1347,10 +1347,22 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.0.2.tgz#3452a24edf9fea138b48fad4a0a028a683da1e40"
   integrity sha512-5tabW/i+9mhrfEOUcLDu2xBPsHJ+X5Orqy9FKpale3SjDA17j5AEpYq5vfy3oAeAHGcvANRCO3NV3d2D6q3NiA==
 
+"@types/node@^12.0.2":
+  version "12.7.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.2.tgz#c4e63af5e8823ce9cc3f0b34f7b998c2171f0c44"
+  integrity sha512-dyYO+f6ihZEtNPDcWNR1fkoTDf3zAK3lAABDze3mz6POyIercH0lEUawUFXlG8xaQZmm1yEBON/4TsYv/laDYg==
+
 "@types/q@^1.5.1":
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.2.tgz#690a1475b84f2a884fd07cd797c00f5f31356ea8"
   integrity sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==
+
+"@types/sax@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@types/sax/-/sax-1.2.0.tgz#6025e0b7fc7cd5f3d83808a6809730bac798565d"
+  integrity sha512-D8ef/GGUjiHuUOiXV6tkJw6Zq2Sm8vcBScJSvj+monDI5YncJ6M3oNIXR7EtmWPVqJw0jsZF2ARN/X5gvGmQSA==
+  dependencies:
+    "@types/node" "*"
 
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
@@ -1732,6 +1744,11 @@ are-we-there-yet@~1.1.2:
   dependencies:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
+
+arg@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.1.tgz#485f8e7c390ce4c5f78257dbea80d4be11feda4c"
+  integrity sha512-SlmP3fEA88MBv0PypnXZ8ZfJhwmDeIE3SP71j37AiXQBXYosPV0x6uISAaHYSlSVhmHOVkomen0tbGk6Anlebw==
 
 argparse@^1.0.7:
   version "1.0.10"
@@ -6822,10 +6839,15 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-"lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.5, lodash@~4.17.10, lodash@~4.17.4:
+"lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.17.5, lodash@~4.17.10, lodash@~4.17.4:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
+
+lodash@^4.17.10:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
 lodash@^4.17.11, lodash@^4.17.14:
   version "4.17.14"
@@ -10103,14 +10125,16 @@ sisteransi@^1.0.0:
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.0.tgz#77d9622ff909080f1c19e5f4a1df0c1b0a27b88c"
   integrity sha512-N+z4pHB4AmUv0SjveWRd6q1Nj5w62m5jodv+GD8lvmbY/83T/rpbJGZOnK5T149OldDj4Db07BSv9xY4K6NTPQ==
 
-sitemap@^2.1.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/sitemap/-/sitemap-2.2.0.tgz#98b8502762c5d7e8c77c9be5061dce85b326f1b0"
-  integrity sha512-9Zoi3UBhSIt5jWENDRUbzsqLMJ+Fha3P2aQ2PRghmh0FOivtHsC4FAJdkAEKHvATajd74BWp/57Yh7kz/UA53Q==
+sitemap@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/sitemap/-/sitemap-4.1.1.tgz#c9b459c7d797e629c61f56b86586d4f67dbf250b"
+  integrity sha512-+8yd66IxyIFEMFkFpVoPuoPwBvdiL7Ap/HS5YD7igqO4phkyTPFIprCAE9NMHehAY5ZGN3MkAze4lDrOAX3sVQ==
   dependencies:
-    lodash "^4.17.10"
-    url-join "^4.0.0"
-    xmlbuilder "^10.0.0"
+    "@types/node" "^12.0.2"
+    "@types/sax" "^1.2.0"
+    arg "^4.1.1"
+    sax "^1.2.4"
+    xmlbuilder "^13.0.0"
 
 slash@^1.0.0:
   version "1.0.0"
@@ -11070,11 +11094,6 @@ urix@^0.1.0:
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
 
-url-join@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/url-join/-/url-join-4.0.0.tgz#4d3340e807d3773bda9991f8305acdcc2a665d2a"
-  integrity sha1-TTNA6AfTdzvamZH4MFrNzCpmXSo=
-
 url-loader@1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/url-loader/-/url-loader-1.1.2.tgz#b971d191b83af693c5e3fea4064be9e1f2d7f8d8"
@@ -11692,10 +11711,10 @@ xml-name-validator@^3.0.0:
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
 
-xmlbuilder@^10.0.0:
-  version "10.1.1"
-  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-10.1.1.tgz#8cae6688cc9b38d850b7c8d3c0a4161dcaf475b0"
-  integrity sha512-OyzrcFLL/nb6fMGHbiRDuPup9ljBycsdCypwuyg5AAHvyWzGfChJpCXMG88AGTIMFhGZ9RccFN1e6lhg3hkwKg==
+xmlbuilder@^13.0.0:
+  version "13.0.2"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-13.0.2.tgz#02ae33614b6a047d1c32b5389c1fdacb2bce47a7"
+  integrity sha512-Eux0i2QdDYKbdbA6AM6xE4m6ZTZr4G4xF9kahI2ukSEMCzwce2eX9WlTI5J3s+NU7hpasFsr8hWIONae7LluAQ==
 
 xmlchars@^1.3.1:
   version "1.3.1"


### PR DESCRIPTION
## Issue Number

#731 

## Purpose/Implementation Notes

this will query the /search endpoint sequentially until there are no more results, ordering experiments by ```id``` rather than ```created_at``` (since it's not currently exposed as an ordering option) 
it takes a little over 1 min to run top to bottom

***I also addressed the versioning of the cachebackend script, which I think was silently broken***

- updates the sitemap npm package
- pulls out the sitemap generation from the cache backend 
- creates a new script for generating a sitemap index file and various sitemaps from a list of urls
- modifies circle ci script to generate staging or production sitemaps
- change robots.txt to use new sitemap index

Note: staging sitemaps should be generated and manually verifiable but not indexed

Further thoughts for future improvements:
- add better SEO in the ```<head>``` of experiments page (should be addressed before deploying this)
- check against s3 and pass in existing sitemaps so only those with <50k are regenerated (revisit sometime before 100k experiments)
- add ```changeFrequency``` to never when processed samples is equal to total sample
- add ```changeFrequency``` to weekly/monthly when there are unprocessed samples
- add more resources! samples can link to their experiments page or a samples detail page?
- possibly consider moving this to a lambda function so its regenerated as every X experiments are surveyed

## Types of changes

* [x] Bugfix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

ran from yarn with no params which works fine, it pulls from the prod API and creates 1 sitemap-```index.xml``` and two ```sitemap-#.xml``` files with a total of 50k+ urls for experiments and saves it to ```/public```

## Checklist

_Put an `x` in the boxes that apply._

* [x] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
* [ ] Any dependent changes have been merged and published in downstream modules

