### PR TITLE
Disable advanced options when aggregating by species

### DIFF
--- a/src/pages/Downloads/DownloadBar.js
+++ b/src/pages/Downloads/DownloadBar.js
@@ -126,7 +126,8 @@ let DownloadBar = ({
                 quantile_normalize: !quantile_normalize,
               })
             }
-            checked={!quantile_normalize}
+            checked={!quantile_normalize && aggregate_by !== 'SPECIES'}
+            disabled={aggregate_by === 'SPECIES'}
           >
             <span>Skip quantile normalization for RNA-seq samples</span>
             <HelpIcon


### PR DESCRIPTION
## Issue Number

close #756 

## Purpose/Implementation Notes

Disable advanced options checkbox to skip quantile normalization when the user aggregates by species.

## Types of changes

* [ ] Bugfix (non-breaking change which fixes an issue)

## Functional tests

Tested locally

## Checklist

* [x] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
* [x] Any dependent changes have been merged and published in downstream modules

## Screenshots

![2019-09-19 16 31 12](https://user-images.githubusercontent.com/1882507/65278843-f0e92080-dafa-11e9-991d-6c4b8fb56df4.gif)
