### PR TITLE
Don't disable quantile normalization when downloading dataset

### DIFF
--- a/src/state/download/actions.js
+++ b/src/state/download/actions.js
@@ -271,7 +271,6 @@ export const startDownload = ({
         start: true,
         data: dataSet,
         token_id: tokenId,
-        quantile_normalize: false,
         ...(receiveUpdates ? { email_ccdl_ok: true } : {}),
         ...(email ? { email_address: email } : {}),
       },


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio/issues/1774

## Purpose/Implementation Notes

Seems we were manually disabling quantile normalization for all datasets when the users triggered a download. 