### PR TITLE
save search filter category query in LS

### DIFF
--- a/src/pages/Search/ResultFilters/FilterCategory.js
+++ b/src/pages/Search/ResultFilters/FilterCategory.js
@@ -5,6 +5,7 @@ import Checkbox from '../../../components/Checkbox';
 import Button from '../../../components/Button';
 import { InputSearch } from '../../../components/Input';
 import HighlightedText from '../../../components/HighlightedText';
+import { useLocalStorage } from '../../../common/hooks';
 
 const MAX_FILTERS = 6;
 
@@ -18,12 +19,20 @@ export function FilterCategory({
   filterValues,
   activeValues,
   formatValue = x => x,
-
   onToggleFilter,
 }) {
   const [query, setQuery] = React.useState('');
+  const [savedQuery, setSavedQuery] = useLocalStorage(
+    `saved-search-filter-query-${title}`,
+    false
+  );
   const [collapsed, setCollapsed] = React.useState(true);
-
+  React.useEffect(() => {
+    if (!query.length && savedQuery) {
+      setQuery(savedQuery);
+      setSavedQuery(false);
+    }
+  }, [savedQuery, setSavedQuery, query, setQuery]);
   // create an array with all the filter values, sometimes the API returns
   // a `'null'` value which we want to ignore.
   const filters = Object.keys(filterValues).filter(x => x !== 'null');
@@ -55,7 +64,10 @@ export function FilterCategory({
           key={filter}
           name={filter}
           className="result-filters__filter-check"
-          onChange={() => onToggleFilter(queryField, filter)}
+          onChange={() => {
+            setSavedQuery(query);
+            onToggleFilter(queryField, filter);
+          }}
           checked={activeValues && activeValues.includes(filter)}
         >
           <HighlightedText text={formatValue(filter)} highlight={query} />
@@ -83,7 +95,6 @@ export function SingleValueFilter({
   count = null,
   filterActive,
   className,
-
   onToggleFilter,
 }) {
   return (


### PR DESCRIPTION
## Issue Number

#767 

## Purpose/Implementation Notes

Since we reload the page on changes to the search query (which includes filtering) we tend to drop state for anything that isn't explicitly part of the search query. This PR preserves the state of the filter filter query so after interaction and reload of the search page the filter query will be stashed in local storage and then repopulated after page load. 

## Types of changes

* [x] Bugfix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

Works in chrome and FF

## Checklist

* [X] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
* [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

![2019-10-17 11 57 17](https://user-images.githubusercontent.com/1075609/67026293-77325b80-f0d5-11e9-9590-6183fa9c9602.gif)

