### PR TITLE
Fix data request slack url

### DIFF
--- a/src/common/slack.js
+++ b/src/common/slack.js
@@ -3,7 +3,7 @@
  */
 
 const SLACK_HOOK_URL =
-  'aHR0cHM6Ly9ob29rcy5zbGFjay5jb20vc2VydmljZXMvVDYyR1g1UlFVL0JMOVQ1MlA2My9KeU5qNmhHamM3U09YZXNnMDFCU2k0VzE=';
+  'aHR0cHM6Ly9ob29rcy5zbGFjay5jb20vc2VydmljZXMvVDYyR1g1UlFVL0JRNEFKQUdLRy9HSERXVXpGcHJWM2Vxa3JtOVMwNHhRajE=';
 
 /**
  * Send data to slack, configured in CCDL channel


### PR DESCRIPTION
We had to reinstall the app and the URL was invalidated.