### PR TITLE
Use organisms field in experiments page

### DIFF
--- a/src/pages/Experiment/index.js
+++ b/src/pages/Experiment/index.js
@@ -79,7 +79,7 @@ let Experiment = ({ match, location: { state }, goBack }) => {
           let totalSamples = experimentData.samples.length;
           const numDownloadableSamples =
             experimentData['num_downloadable_samples'];
-          let organisms = experimentData.organism_names;
+          let { organisms } = experimentData;
 
           // for users coming from the search, see if there's any experiment's data in the url state
           if (isLoading && comesFromSearch && state.result) {
@@ -89,7 +89,7 @@ let Experiment = ({ match, location: { state }, goBack }) => {
               samples: [],
             };
             totalSamples = state.result.total_samples_count;
-            organisms = state.result.organism_names;
+            organisms = state.result.organisms;
           }
 
           // Ensure that the url has the correct slug

--- a/src/pages/Search/Result/index.js
+++ b/src/pages/Search/Result/index.js
@@ -50,7 +50,7 @@ const Result = ({ result, query }) => {
                 publication_authors: result.publication_authors,
                 source_url: result.source_url,
                 source_database: result.source_database,
-                organism_names: result.organism_names,
+                organisms: result.organism_names,
                 samples: [],
               },
             })}


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

Came up after the last deploy, we removed the field `organism_names` in favor of `organisms` in the experiments endpoint.

## Types of changes

* [x] Bugfix (non-breaking change which fixes an issue)

## Functional tests

Tested locally

## Checklist

* [ ] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
* [ ] Any dependent changes have been merged and published in downstream modules
