### PR TITLE
Include quantile normalize option when regenerating dataset

### DIFF
--- a/src/state/download/actions.js
+++ b/src/state/download/actions.js
@@ -313,7 +313,7 @@ export const startDownload = ({
  * to create a new dataset with the same data and redirect to it's page.
  */
 export const regenerateDataSet = dataSet => async dispatch => {
-  const { data, aggregate_by, scale_by } = dataSet;
+  const { data, aggregate_by, scale_by, quantile_normalize } = dataSet;
 
   try {
     // 1. create a new dataset
@@ -323,6 +323,7 @@ export const regenerateDataSet = dataSet => async dispatch => {
       data,
       aggregate_by,
       scale_by,
+      quantile_normalize,
     });
 
     // 3. redirect to the new dataset page, where the user will be able to add an email


### PR DESCRIPTION
## Issue Number

#778 

## Purpose/Implementation Notes

Missed one of the options when re-generating dataset.

## Types of changes

* [x] Bugfix (non-breaking change which fixes an issue)
