### PR TITLE
Fix missing filter category when opening search url

### DIFF
--- a/src/state/search/actions.js
+++ b/src/state/search/actions.js
@@ -169,7 +169,11 @@ export function fetchResults({
               [lastFilterName]: undefined,
             },
           });
-          previousFilters = previousFacets;
+          previousFilters = {
+            ...previousFacets,
+            organism: previousFacets.organism_names,
+            platform: previousFacets.platform_accession_codes,
+          };
         }
 
         filters = {


### PR DESCRIPTION
## Issue Number

close #796 

## Purpose/Implementation Notes

When a search URL with filters applied is visited we try to get the filters from the same query without the last filter applied, in order to get the numbers for that category.

The frontend stores the filters in an object where the data for the organism section is under `organisms` which is the same name as the parameter in the API `organisms.

In the case of the API, these fields are named differently. The organisms information is sent in a field named `organism_names` and the API parameter is `organisms`. Maybe we should consider using the same field for those? This would allow us to avoid changes like the ones here.

This PR should fix the problem while we decide.

## Types of changes

* [x] Bugfix (non-breaking change which fixes an issue)

## Functional tests

Tested locally.

## Checklist

* [x] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
* [x] Any dependent changes have been merged and published in downstream modules
