### PR TITLE
Add CI staging deploy with ZEIT Now

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,9 +19,21 @@ jobs:
       - run: yarn install --ignore-engines
       - run: yarn run test:integration
 
+  deploy-staging:
+    docker:
+      - image: circleci/node:8
+    steps:
+      - checkout
+      - run: yarn global add now
+      - run: $(yarn global bin)/now --prod --token $ZEIT_TOKEN --local-config now.staging.json --scope ccdl
+
 workflows:
   version: 2
   test-and-deploy:
     jobs:
       - test
       - test_user
+      - deploy-staging:
+        filters:
+          branches:
+            only: dev

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,6 @@ workflows:
       - test
       - test_user
       - deploy-staging:
-        filters:
-          branches:
-            only: dev
+          filters:
+            branches:
+              only: dev

--- a/now.json
+++ b/now.json
@@ -1,9 +1,6 @@
 {
   "version": 2,
   "alias": "refinebio",
-  "env": {
-    "REACT_APP_API_HOST": "https://api.refine.bio"
-  },
   "github": {
     "silent": true
   }

--- a/now.staging.json
+++ b/now.staging.json
@@ -1,10 +1,13 @@
 {
   "version": 2,
-  "alias": "refinebio-staging",
-  "env": {
-    "REACT_APP_API_HOST": "https://api.staging.refine.bio"
+  "alias": ["refinebio-staging.now.sh"],
+  "build": {
+    "env": {
+      "REACT_APP_API_HOST": "https://api.staging.refine.bio"
+    }
   },
   "github": {
+    "autoAlias": false,
     "silent": true
   }
 }


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

Turns out Zeit doesn't support different environment variables for each deployment, saw somewhere they are working on this.

We use them to differentiate between the API URLs for prod/staging. 

This solution deploys staging with the Now CLI, and points the API to staging. Production and all the deployment previews will keep pointing to the prod API.

