### PR TITLE
Use node10 on now's circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
 
   deploy-staging:
     docker:
-      - image: circleci/node:8
+      - image: circleci/python:3-node
     steps:
       - checkout
       - run: yarn global add now


### PR DESCRIPTION
Previous staging deploy failed with:

```
error now@17.0.4: The engine "node" is incompatible with this module. Expected version ">= 10". Got "8.17.0"
error Found incompatible module.
```

This updates the docker image where it should be executed.