### PR TITLE
Update slack webhook url

### DIFF
--- a/src/common/slack.js
+++ b/src/common/slack.js
@@ -4,7 +4,7 @@
 
 // btoa(webhook_url)
 const SLACK_HOOK_URL =
-  'aHR0cHM6Ly9ob29rcy5zbGFjay5jb20vc2VydmljZXMvVDYyR1g1UlFVL0JCUzUyVDc5OC9UWnZZSGkzcnFyY29aSWYyaFlCVDZVdTA=';
+  'aHR0cHM6Ly9ob29rcy5zbGFjay5jb20vc2VydmljZXMvVDYyR1g1UlFVL0JCUzUyVDc5OC9vbTBlMWplM0ZObTJuMk5hblFHZ0pSMW4=';
 
 // get IP
 const getIP = async () => {


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

I posted the slack webhook URL by accident to https://github.com/AlexsLemonade/refinebio/pull/2193, which invalidated it.

This updates it to the new one.

## Types of changes

* [ ] Bugfix (non-breaking change which fixes an issue)

## Functional tests

None

## Checklist

* [ ] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
* [ ] Any dependent changes have been merged and published in downstream modules
