### PR TITLE
show data processing modal after submit

### DIFF
--- a/src/components/Modal/ModalManager.js
+++ b/src/components/Modal/ModalManager.js
@@ -29,7 +29,7 @@ export default class ModalManager extends React.Component {
   };
 
   state = {
-    modalOpen: false,
+    modalOpen: this.props.defaultOpen || false,
     childOpen: false,
   };
 


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

* Adds an option property to a modal manager to default the modal to open state
* Adds mechanism that saves to local storage that the modal has been display so we dont show it everytime that experiment appears
* Clean up local storage when we fetch the latest state to prevent accumulation of old data

## Types of changes


* [x] Bugfix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

Downloaded a bunch of single experiment datasets.

## Checklist

* [x] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
* [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

![2020-04-30 17 12 28](https://user-images.githubusercontent.com/1075609/80759861-f9c8b880-8b05-11ea-8694-3c5be24f3ad7.gif)
