### PR TITLE
download experiment notes

### DIFF
--- a/pages/_app.scss
+++ b/pages/_app.scss
@@ -141,6 +141,10 @@ fieldset {
   margin-bottom: 1rem;
 }
 
+.mb-1-5 {
+  margin-bottom: 1.5rem;
+}
+
 .mb-2 {
   margin-bottom: 2rem;
 }

--- a/src/components/DataSetSampleActions.js
+++ b/src/components/DataSetSampleActions.js
@@ -97,7 +97,7 @@ export function RemoveFromDatasetButton({
       {samplesInDataset && (
         <p className="dataset-remove-button__info-text">
           <IoIosInformationCircle className="dataset-remove-button__info-icon" />{' '}
-          {samplesInDataset} Samples are already in Dataset
+          {samplesInDataset} Samples already in My Dataset
         </p>
       )}
     </div>
@@ -122,7 +122,7 @@ function AddRemainingSamples({ onAdd, totalSamplesInDataset }) {
       <Button text="Add Remaining" buttonStyle="secondary" onClick={onAdd} />
       <p className="dataset-add-button__info-text">
         <IoIosInformationCircle className="dataset-remove-button__info-icon" />{' '}
-        {totalSamplesInDataset} Samples are already in Dataset
+        {totalSamplesInDataset} Samples already in My Dataset
       </p>
     </div>
   );

--- a/src/components/DatasetDownloadOptionsForm.js
+++ b/src/components/DatasetDownloadOptionsForm.js
@@ -82,7 +82,7 @@ export const TransformationOptions = () => {
         Transformation{' '}
         <HelpIcon
           alt="What does transformation mean?"
-          url="//docs.refine.bio/en/latest/main_text.html#transformations"
+          url="//docs.refine.bio/en/latest/main_text.html#gene-transformations"
         />
       </div>{' '}
       <Dropdown

--- a/src/components/DownloadExperiment.js
+++ b/src/components/DownloadExperiment.js
@@ -128,7 +128,7 @@ const DatasetDownloadOptionsContent = ({
 }) => {
   return (
     <div>
-      <h1 className="mb-1">Download Options</h1>
+      <h1 className="mb-1">Download All Samples Now</h1>
       <hr className="mb-2" />
       <DatasetDownloadOptionsForm
         dataset={dataset}
@@ -139,6 +139,7 @@ const DatasetDownloadOptionsContent = ({
         startDownload
       >
         <>
+          <p className="emphasis mb-2">Download Options</p>
           {hasMultipleSpecies && (
             <div className="flex-row mb-2">
               <AggreationOptions />

--- a/src/components/DownloadExperiment.js
+++ b/src/components/DownloadExperiment.js
@@ -129,7 +129,7 @@ const DatasetDownloadOptionsContent = ({
   return (
     <div>
       <h1 className="mb-1">Download All Samples Now</h1>
-      <hr className="mb-2" />
+      <hr className="mb-1-5" />
       <DatasetDownloadOptionsForm
         dataset={dataset}
         setDataset={setDataset}

--- a/src/pages/experiments/Experiment.scss
+++ b/src/pages/experiments/Experiment.scss
@@ -23,6 +23,7 @@
   &__dataset-buttons {
     flex-direction: column;
     justify-content: end;
+    align-items: end;
 
     .dataset-download__button {
       margin-top: 1rem;

--- a/src/pages/experiments/index.js
+++ b/src/pages/experiments/index.js
@@ -284,11 +284,7 @@ let Experiment = ({
           </div>
         </div>
       </div>
-      <SamplesTableBlock
-        experiment={experiment}
-        dataset={dataset}
-        setDataset={setDataset}
-      />
+      <SamplesTableBlock experiment={experiment} />
     </Hightlight>
   );
 };
@@ -338,7 +334,7 @@ function ExperimentHeaderRow({ label, children }) {
   );
 }
 
-function SamplesTableBlock({ experiment, dataset, setDataset }) {
+function SamplesTableBlock({ experiment }) {
   const [expanded, setExpanded] = React.useState(false);
   const totalColumns = 4 + (experiment ? experiment.sample_metadata.length : 0);
   const style = expanded
@@ -371,13 +367,6 @@ function SamplesTableBlock({ experiment, dataset, setDataset }) {
                       },
                     }}
                   />
-                  {!dataset.is_processing && (
-                    <DownloadExperiment
-                      experiment={experiment}
-                      dataset={dataset}
-                      setDataset={setDataset}
-                    />
-                  )}
                 </div>
               )}
             </div>

--- a/src/pages/search/Result/Result.scss
+++ b/src/pages/search/Result/Result.scss
@@ -48,10 +48,9 @@
   &__dataset-buttons {
     flex-direction: column;
     justify-content: flex-end;
-    align-content: end;
+    align-items: end;
     position: relative;
     min-height: 90px;
-    min-width: 180px;
 
     .dataset-download__button {
       margin-top: 1rem;
@@ -130,6 +129,10 @@
 
 .dataset-remove-button,
 .dataset-add-button {
+  display: flex;
+  flex-direction: column;
+  align-items: end;
+
   &__added {
     display: flex;
     align-items: center;


### PR DESCRIPTION
## Issue Number

#894 #895 #897 

## Purpose/Implementation Notes

Removes download now from experiment samples block
Makes layout for the buttons consistent across screens
Fixes url to transformations options in download experiment form

## Types of changes

* [X] Bugfix (non-breaking change which fixes an issue)

## Functional tests

Tested locally

## Checklist

* [x] Lint and unit tests pass locally with my changes

## Screenshots

![Screen Shot 2020-05-18 at 12 59 56 PM](https://user-images.githubusercontent.com/1075609/82239888-7ed60f00-9907-11ea-8b46-ad83b70ffdc1.png)
![Screen Shot 2020-05-18 at 12 59 51 PM](https://user-images.githubusercontent.com/1075609/82239892-7f6ea580-9907-11ea-9486-e2eaa23bf895.png)
![Screen Shot 2020-05-18 at 12 59 46 PM](https://user-images.githubusercontent.com/1075609/82239897-809fd280-9907-11ea-99e1-d212628cdec5.png)
![Screen Shot 2020-05-18 at 12 59 43 PM](https://user-images.githubusercontent.com/1075609/82239898-809fd280-9907-11ea-8c3e-3b6cf37945f2.png)
![Screen Shot 2020-05-18 at 12 59 38 PM](https://user-images.githubusercontent.com/1075609/82239899-809fd280-9907-11ea-9602-796ef4bd103f.png)

