### PR TITLE
Data requests as tickets

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -11,7 +11,9 @@ module.exports = withImages(
     target: 'serverless',
     env: {
       REACT_APP_API_HOST: ApiHost,
+      GITHUB_URL: process.env.GITHUB_URL,
       GITHUB_TOKEN: process.env.GITHUB_TOKEN,
+      HUBSPOT_LIST_ID: process.env.HUBSPOT_LIST_ID,
       HUBSPOT_APIKEY: process.env.HUBSPOT_APIKEY,
       SLACK_HOOK_URL: process.env.SLACK_HOOK_URL,
     },

--- a/next.config.js
+++ b/next.config.js
@@ -12,6 +12,8 @@ module.exports = withImages(
     env: {
       REACT_APP_API_HOST: ApiHost,
       GITHUB_TOKEN: process.env.GITHUB_TOKEN,
+      HUBSPOT_APIKEY: process.env.HUBSPOT_APIKEY,
+      SLACK_HOOK_URL: process.env.SLACK_HOOK_URL,
     },
     webpack: (config, { isServer, dev, webpack }) => {
       // add custom webpack config only for the client side in production

--- a/next.config.js
+++ b/next.config.js
@@ -11,6 +11,7 @@ module.exports = withImages(
     target: 'serverless',
     env: {
       REACT_APP_API_HOST: ApiHost,
+      GITHUB_TOKEN: process.env.GITHUB_TOKEN,
     },
     webpack: (config, { isServer, dev, webpack }) => {
       // add custom webpack config only for the client side in production

--- a/pages/api/data-requests/index.js
+++ b/pages/api/data-requests/index.js
@@ -14,7 +14,8 @@ export default async (req, res) => {
   
   switch (method) {
     case 'POST':
-      let githubResponse, hubspotResponse;
+      let githubResponse;
+      let hubspotResponse;
 
       // If query exists, then this is a request from RequestSearchButton
       if (query !== undefined) {
@@ -33,7 +34,7 @@ export default async (req, res) => {
         if (!githubResponse.ok && !hubspotResponse.ok) {
           failedRequest = "GitHub and HubSpot"
         }
-        else if (!githubRequest.ok) {
+        else if (!githubResponse.ok) {
           failedRequest = "GitHub"
         }
         else {

--- a/pages/api/data-requests/index.js
+++ b/pages/api/data-requests/index.js
@@ -13,7 +13,7 @@ export default async (req, res) => {
   } = req
   
   switch (method) {
-    case 'POST':
+    case 'POST': {
       let githubResponse;
       let hubspotResponse;
 
@@ -55,9 +55,11 @@ export default async (req, res) => {
       }
 
       break
-    default:
+    }
+    default: {
       res.setHeader('Allow', ['POST'])
       res.status(405).end(`Method ${method} Not Allowed`)
+    }
   }
 
   res.end();

--- a/pages/api/data-requests/index.js
+++ b/pages/api/data-requests/index.js
@@ -1,14 +1,10 @@
 /*
-Payload should be the serialized form of the request
+Payload should be accessionCode/query depending on button, and the serialized form of the request
 */
 
-import { submitSearchDataRequest as slackSearchRequest } from '../../../src/common/slack';
-import { submitSearchDataRequest as githubSearchRequest } from '../../../src/common/github';
-import { submitSearchDataRequest as hubspotSearchRequest } from '../../../src/common/hubspot';
-
-import { submitExperimentDataRequest as slackExperimentRequest } from '../../../src/common/slack';
-import { submitExperimentDataRequest as githubExperimentRequest } from '../../../src/common/github';
-import { submitExperimentDataRequest as hubspotExperimentRequest } from '../../../src/common/hubspot';
+import { submitSearchDataRequest as slackSearchRequest, submitExperimentDataRequest as slackExperimentRequest } from '../../../src/common/slack';
+import { submitSearchDataRequest as githubSearchRequest, submitExperimentDataRequest as githubExperimentRequest } from '../../../src/common/github';
+import { submitSearchDataRequest as hubspotSearchRequest, submitExperimentDataRequest as hubspotExperimentRequest } from '../../../src/common/hubspot';
 
 export default async (req, res) => {
   const {
@@ -18,8 +14,7 @@ export default async (req, res) => {
   
   switch (method) {
     case 'POST':
-      let githubResponse;
-      let hubspotResponse;
+      let githubResponse, hubspotResponse;
 
       // If query exists, then this is a request from RequestSearchButton
       if (query !== undefined) {
@@ -52,7 +47,7 @@ export default async (req, res) => {
             await slackExperimentRequest(query, values, failedRequest);
         }
 
-        res.status(400).json({ message: `${failedRequest} failed` })
+        res.status(500).json({ message: `${failedRequest} failed` })
       } 
       else {
         res.status(200).json({ message: 'GitHub and HubSpot succeeded' })

--- a/pages/api/data-requests/index.js
+++ b/pages/api/data-requests/index.js
@@ -1,0 +1,68 @@
+/*
+Payload should be the serialized form of the request
+*/
+
+import { submitSearchDataRequest as slackSearchRequest } from '../../../src/common/slack';
+import { submitSearchDataRequest as githubSearchRequest } from '../../../src/common/github';
+import { submitSearchDataRequest as hubspotSearchRequest } from '../../../src/common/hubspot';
+
+import { submitExperimentDataRequest as slackExperimentRequest } from '../../../src/common/slack';
+import { submitExperimentDataRequest as githubExperimentRequest } from '../../../src/common/github';
+import { submitExperimentDataRequest as hubspotExperimentRequest } from '../../../src/common/hubspot';
+
+export default async (req, res) => {
+  const {
+    body: { accessionCode, query, values },
+    method,
+  } = req
+  
+  switch (method) {
+    case 'POST':
+      let githubResponse;
+      let hubspotResponse;
+
+      // If query exists, then this is a request from RequestSearchButton
+      if (query !== undefined) {
+        githubResponse = await githubSearchRequest(query, values);
+        hubspotResponse = await hubspotSearchRequest(query, values);
+      }
+      // If accessionCode exists, then this is a request from RequestExperimentButton
+      else if (accessionCode !== undefined) {
+        githubResponse = await githubExperimentRequest(accessionCode, values);
+        hubspotResponse = await hubspotExperimentRequest(accessionCode, values);
+      }
+
+      // Send to slack instead if GitHub or HubSpot request failed
+      if (!githubResponse.ok || !hubspotResponse.ok) {
+        let failedRequest;
+        if (!githubResponse.ok && !hubspotResponse.ok) {
+          failedRequest = "GitHub and HubSpot"
+        }
+        else if (!githubRequest.ok) {
+          failedRequest = "GitHub"
+        }
+        else {
+          failedRequest = "HubSpot"
+        }
+
+        if (query !== undefined) {
+            await slackSearchRequest(query, values, failedRequest);
+        }
+        else if (accessionCode !== undefined) {
+            await slackExperimentRequest(query, values, failedRequest);
+        }
+
+        res.status(400).json({ message: `${failedRequest} failed` })
+      } 
+      else {
+        res.status(200).json({ message: 'GitHub and HubSpot succeeded' })
+      }
+
+      break
+    default:
+      res.setHeader('Allow', ['POST'])
+      res.status(405).end(`Method ${method} Not Allowed`)
+  }
+
+  res.end();
+}

--- a/pages/api/data-requests/index.js
+++ b/pages/api/data-requests/index.js
@@ -41,10 +41,10 @@ export default async (req, res) => {
           failedRequest = "HubSpot"
         }
 
-        if (query !== undefined) {
+        if (values.request_type === 'search') {
             await slackSearchRequest(values, failedRequest);
         }
-        else if (accessionCode !== undefined) {
+        else if (values.request_type === 'experiment') {
             await slackExperimentRequest(values, failedRequest);
         }
 

--- a/src/api/requests.js
+++ b/src/api/requests.js
@@ -5,8 +5,10 @@
 import fetch from 'isomorphic-unfetch';
 
 // Used by both RequestSearchButton and RequestExperimentButton
-// requestBody should contain either a search query or accessionCode depending on the button, and the form values as values: {}
+// requestBody has values TODO make body just value params not one value which contains params
 export const dataRequest = async requestBody => {
+  requestBody.values.navigatorUserAgent = navigator.userAgent;
+
   const response = await fetch(`api/data-requests`, {
     method: 'POST',
     headers: {

--- a/src/api/requests.js
+++ b/src/api/requests.js
@@ -1,0 +1,19 @@
+/**
+ * Client-side interface for pages/api/experiment-requests
+ */
+
+import fetch from 'isomorphic-unfetch';
+
+// Used by both RequestSearchButton and RequestExperimentButton
+// requestBody should contain either a search query or accessionCode depending on the button, and the form values as values: {}
+export const dataRequest = async requestBody => {
+  const response = await fetch(`api/data-requests`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(requestBody),
+  });
+
+  return response.json();
+};

--- a/src/common/github.js
+++ b/src/common/github.js
@@ -2,7 +2,6 @@
  * This file contains helper methods that create new GitHub requests
  */
 
-// btoa
 const GITHUB_URL = 'https://api.github.com/repos/BEW111/testrepo/issues'; // this is a test github repo, change to actual repo once done
 const { GITHUB_TOKEN } = process.env;
 

--- a/src/common/github.js
+++ b/src/common/github.js
@@ -2,7 +2,8 @@
  * This file contains helper methods that create new GitHub requests
  */
 
-const GITHUB_URL = 'https://api.github.com/repos/BEW111/testrepo/issues'; // Change to actual repo once done
+// btoa
+const GITHUB_URL = 'https://api.github.com/repos/BEW111/testrepo/issues'; // this is a test github repo, change to actual repo once done
 const { GITHUB_TOKEN } = process.env;
 
 // Sends an issue to GitHub

--- a/src/common/github.js
+++ b/src/common/github.js
@@ -18,10 +18,26 @@ export async function createIssue(params) {
   });
 }
 
-export async function submitExperimentDataRequestGithub(accessionCode) {
+export async function submitSearchDataRequest(query, values) {
+  return createIssue({
+    title: `Dataset Request ${values.accession_codes}`,
+    body: `### Context\r\n\r\nA user requested ${
+      values.accession_codes
+    } for the search term ["${query}"](https://www.refine.bio/search?q=${query})
+        \r\n\r\n### Problem or idea\r\n\r\n(Add description of experiment/problem here)
+        \r\n\r\n### Solution or next step\r\n\r\n(Add solution/next step here)`,
+    labels: [
+      {
+        name: 'dataset request',
+      },
+    ],
+  });
+}
+
+export async function submitExperimentDataRequest(accessionCode) {
   return createIssue({
     title: `Dataset Request ${accessionCode}`,
-    body: `### Context\r\n\r\nA user requested \`[${accessionCode}]\`(https://www.refine.bio/experiments/${accessionCode})
+    body: `### Context\r\n\r\nA user requested [${accessionCode}](https://www.refine.bio/experiments/${accessionCode})
         \r\n\r\n### Problem or idea\r\n\r\n(Add description of experiment/problem here)
         \r\n\r\n### Solution or next step\r\n\r\n(Add solution/next step here)`,
     labels: [

--- a/src/common/github.js
+++ b/src/common/github.js
@@ -3,7 +3,7 @@
  */
 
 const GITHUB_URL = 'https://api.github.com/repos/BEW111/testrepo/issues'; // this is a test github repo, change to actual repo once done
-const { GITHUB_TOKEN } = process.env;
+const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
 
 // Sends an issue to GitHub
 export async function createIssue(params) {

--- a/src/common/github.js
+++ b/src/common/github.js
@@ -3,7 +3,7 @@
  */
 
 const GITHUB_URL = 'https://api.github.com/repos/BEW111/testrepo/issues'; // Change to actual repo once done
-const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
+const { GITHUB_TOKEN } = process.env;
 
 // Sends an issue to GitHub
 export async function createIssue(params) {
@@ -21,7 +21,7 @@ export async function createIssue(params) {
 export async function submitExperimentDataRequestGithub(accessionCode) {
   return createIssue({
     title: `Dataset Request ${accessionCode}`,
-    body: `### Context\r\n\r\nA user requested [${accessionCode}](https://www.refine.bio/experiments/${accessionCode})
+    body: `### Context\r\n\r\nA user requested \`[${accessionCode}]\`(https://www.refine.bio/experiments/${accessionCode})
         \r\n\r\n### Problem or idea\r\n\r\n(Add description of experiment/problem here)
         \r\n\r\n### Solution or next step\r\n\r\n(Add solution/next step here)`,
     labels: [

--- a/src/common/github.js
+++ b/src/common/github.js
@@ -1,0 +1,33 @@
+/**
+ * This file contains helper methods that create new GitHub requests
+ */
+
+const GITHUB_URL = 'https://api.github.com/repos/BEW111/testrepo/issues'; // Change to actual repo once done
+const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
+
+// Sends an issue to GitHub
+export async function createIssue(params) {
+  return fetch(GITHUB_URL, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/vnd.github.v3+json',
+      Authorization: `token ${GITHUB_TOKEN}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(params),
+  });
+}
+
+export async function submitExperimentDataRequestGithub(accessionCode) {
+  return createIssue({
+    title: `Dataset Request ${accessionCode}`,
+    body: `### Context\r\n\r\nA user requested [${accessionCode}](https://www.refine.bio/experiments/${accessionCode})
+        \r\n\r\n### Problem or idea\r\n\r\n(Add description of experiment/problem here)
+        \r\n\r\n### Solution or next step\r\n\r\n(Add solution/next step here)`,
+    labels: [
+      {
+        name: 'dataset request',
+      },
+    ],
+  });
+}

--- a/src/common/github.js
+++ b/src/common/github.js
@@ -18,12 +18,14 @@ export async function createIssue(params) {
   });
 }
 
-export async function submitSearchDataRequest(query, values) {
+export async function submitSearchDataRequest(values) {
   return createIssue({
     title: `Dataset Request ${values.accession_codes}`,
     body: `### Context\r\n\r\nA user requested ${
       values.accession_codes
-    } for the search term ["${query}"](https://www.refine.bio/search?q=${query})
+    } for the search term ["${values.query}"](https://www.refine.bio/search?q=${
+      values.query
+    })
         \r\n\r\n### Problem or idea\r\n\r\n(Add description of experiment/problem here)
         \r\n\r\n### Solution or next step\r\n\r\n(Add solution/next step here)`,
     labels: [
@@ -34,10 +36,12 @@ export async function submitSearchDataRequest(query, values) {
   });
 }
 
-export async function submitExperimentDataRequest(accessionCode) {
+export async function submitExperimentDataRequest(values) {
   return createIssue({
-    title: `Dataset Request ${accessionCode}`,
-    body: `### Context\r\n\r\nA user requested [${accessionCode}](https://www.refine.bio/experiments/${accessionCode})
+    title: `Dataset Request ${values.accession_codes}`,
+    body: `### Context\r\n\r\nA user requested [${
+      values.accession_codes
+    }](https://www.refine.bio/experiments/${values.accession_codes})
         \r\n\r\n### Problem or idea\r\n\r\n(Add description of experiment/problem here)
         \r\n\r\n### Solution or next step\r\n\r\n(Add solution/next step here)`,
     labels: [

--- a/src/common/github.js
+++ b/src/common/github.js
@@ -2,7 +2,7 @@
  * This file contains helper methods that create new GitHub requests
  */
 
-const GITHUB_URL = 'https://api.github.com/repos/BEW111/testrepo/issues'; // this is a test github repo, change to actual repo once done
+const GITHUB_URL = process.env.GITHUB_URL;
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
 
 // Sends an issue to GitHub

--- a/src/common/hubspot.js
+++ b/src/common/hubspot.js
@@ -1,0 +1,165 @@
+/**
+ * This file contains helper methods that update the hubspot list
+ */
+
+// Testing stuff right now, so this all goes to a test HubSpot list
+
+// const PORTAL_ID = "7917739";
+const LIST_ID = '1';
+// const FORM_ID = "9595af37-41d3-4df7-ab8a-dd07aae1acf7"
+// ea84e96a-15f2-4bc7-8240-7ae27223b4ef test form 2
+
+const HUBSPOT_LIST_URL = `https://api.hubapi.com/contacts/v1/lists/${LIST_ID}`;
+// const HUBSPOT_FORM_URL = 'https://api.hsforms.com/submissions/v3/integration';
+// const HUBSPOT_TOKEN = process.env.HUBSPOT_TOKEN;
+const HAPIKEY = '8b29bb28-7ae7-4815-9975-2c05d0326b74'; // using personal api key for now will delete later
+const PROXY_URL = 'https://cors-anywhere.herokuapp.com/'; // idk if this is the best way to do this but this fixes the problem with CORS
+
+// get IP
+const getIP = async () => {
+  try {
+    const resp = await fetch('https://api.ipify.org?format=json');
+    const json = await resp.json();
+    return json.ip || 'Unknown IP';
+  } catch {
+    return 'Unknown IP';
+  }
+};
+
+// Creates a new contact
+export async function createContact(params) {
+  let newContact;
+  await fetch(
+    `${PROXY_URL}https://api.hubapi.com/contacts/v1/contact/?hapikey=${HAPIKEY}`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(params),
+    }
+  )
+    .then(response => response.json())
+    .then(data => {
+      newContact = data;
+    });
+  return newContact;
+}
+
+// Adds a contact to the contact list
+export async function addToContactList(params) {
+  return fetch(`${PROXY_URL + HUBSPOT_LIST_URL}/add?hapikey=${HAPIKEY}`, {
+    method: 'POST',
+    headers: {
+      // Authorization: `Bearer ${HUBSPOT_TOKEN}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(params),
+  });
+}
+
+// Gets all contacts from the contact list
+export async function getContactList() {
+  let contacts;
+  await fetch(
+    `${PROXY_URL + HUBSPOT_LIST_URL}/contacts/all?hapikey=${HAPIKEY}`,
+    {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    }
+  )
+    .then(response => response.json())
+    .then(data => {
+      contacts = data;
+    });
+  return contacts;
+}
+
+/*
+// Submits data to specified form
+export async function submitFormData(params) {
+    const form_url = HUBSPOT_FORM_URL+"/submit/"+PORTAL_ID+"/"+FORM_ID;
+    console.log(form_url);
+    return fetch(form_url, {
+        method: 'POST',
+        headers: {
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify(params),
+    });
+}
+*/
+
+// Might want to move this code into same file as github.js since they should be ran together anyway?
+export async function submitExperimentDataRequestHubspot(
+  accessionCode,
+  values
+) {
+  const ip = await getIP();
+
+  // First check if the contact is already on the list
+  // const contacts = await getContactList();
+
+  // Create a new contact
+  await createContact({
+    properties: [
+      {
+        property: 'email',
+        value: values.email,
+      },
+      {
+        property: 'dataset_request_details',
+        value: `Requested experiment ${accessionCode}
+                    \r\nPediatric cancer research: ${
+                      values.pediatric_cancer_research
+                    }
+                    \r\nPrimary approach: ${values.approach}
+                    \r\nAdditional notes: ${values.comments}
+                    \r\n${
+                      values.email_updates
+                        ? '(Wants email updates)'
+                        : '(Does not want email updates)'
+                    }
+                    \r\nIP: ${ip}
+                    `,
+      },
+    ],
+  });
+
+  // Add that contact to the list
+  await addToContactList({
+    emails: [values.email],
+  });
+
+  /*
+  await submitFormData({
+        fields: [
+            {
+                name: 'pediatric_cancer',
+                value: values.pediatric_cancer,
+            },
+            {
+                name: 'primary_approach',
+                value: values.approach,
+            },
+            {
+                name: 'email',
+                value: values.email,
+            },
+            {
+                name: 'email_updates',
+                value: values.email_updates ? "true" : "false",
+            },
+            {
+                name: 'comments',
+                value: values.comments,
+            },
+        ],
+        context: {
+            ipAddress: toString(ip),
+        }
+    });
+    */
+}

--- a/src/common/hubspot.js
+++ b/src/common/hubspot.js
@@ -120,10 +120,10 @@ export async function updateContactList(email, newDetails) {
   });
 }
 
-export async function submitSearchDataRequest(query, values) {
+export async function submitSearchDataRequest(values) {
   const newDetails = `Requested experiment(s) ${
     values.accession_codes
-  } for search term "${query}"\nPediatric cancer research: ${
+  } for search term "${values.query}"\nPediatric cancer research: ${
     values.pediatric_cancer
   }\nPrimary approach: ${values.approach}\n\nAdditional Notes:\n${
     values.comments
@@ -136,12 +136,12 @@ export async function submitSearchDataRequest(query, values) {
   return updateContactList(values.email, newDetails);
 }
 
-export async function submitExperimentDataRequest(accessionCode, values) {
-  const newDetails = `Requested experiment ${accessionCode}\nPediatric cancer research: ${
-    values.pediatric_cancer
-  }\nPrimary approach: ${values.approach}\n\nAdditional Notes:\n${
-    values.comments
-  }\n\n${
+export async function submitExperimentDataRequest(values) {
+  const newDetails = `Requested experiment ${
+    values.accession_codes
+  }\nPediatric cancer research: ${values.pediatric_cancer}\nPrimary approach: ${
+    values.approach
+  }\n\nAdditional Notes:\n${values.comments}\n\n${
     values.email_updates
       ? '(Wants email updates)'
       : '(Does not want email updates)'

--- a/src/common/hubspot.js
+++ b/src/common/hubspot.js
@@ -4,7 +4,7 @@
 
 // ID for HubSpot list that contacts should be added to (currently goes to a test list)
 const LIST_ID = '1'; // this is a test list ID, change to actual list ID once done
-const { HUBSPOT_APIKEY } = process.env;
+const HUBSPOT_APIKEY = process.env.HUBSPOT_APIKEY;
 
 export async function createContact(params) {
   return fetch(

--- a/src/common/hubspot.js
+++ b/src/common/hubspot.js
@@ -2,8 +2,10 @@
  * This file contains helper methods that update the hubspot list
  */
 
-// ID for HubSpot list that contacts should be added to (currently goes to a test list)
-const LIST_ID = '1'; // this is a test list ID, change to actual list ID once done
+// ID for HubSpot list that contacts should be added to
+// should look like https://app.hubspot.com/contacts/[PORTAL_ID]/lists/[LIST_ID]
+// portal ID will depend on the user but is not needed as an env variable (because of api key)
+const LIST_ID = process.env.HUBSPOT_LIST_ID;
 const HUBSPOT_APIKEY = process.env.HUBSPOT_APIKEY;
 
 export async function createContact(params) {

--- a/src/common/hubspot.js
+++ b/src/common/hubspot.js
@@ -79,7 +79,6 @@ export async function updateContact(email, params) {
 export async function updateContactList(email, newDetails) {
   let details = newDetails;
 
-  // Check if contact exists
   const contactData = await getContact(email);
 
   // Create a new contact email isn't found
@@ -106,7 +105,6 @@ export async function updateContactList(email, newDetails) {
       details = `${newDetails}\n----------\n${oldDatasetRequestDetails}`;
     }
 
-    // Update that contact with the new information
     await updateContact(email, {
       properties: [
         {
@@ -117,7 +115,6 @@ export async function updateContactList(email, newDetails) {
     });
   }
 
-  // Add that contact to the list
   return addToContactList({
     emails: [email],
   });

--- a/src/common/hubspot.js
+++ b/src/common/hubspot.js
@@ -10,26 +10,13 @@ const HUBSPOT_LIST_URL = `https://api.hubapi.com/contacts/v1/lists/${LIST_ID}`;
 const HAPIKEY = '8b29bb28-7ae7-4815-9975-2c05d0326b74'; // using personal api key for now will delete later
 const PROXY_URL = 'https://cors-anywhere.herokuapp.com/'; // idk if this is the best way to do this but this fixes the problem with CORS
 
-// get IP
-const getIP = async () => {
-  try {
-    const resp = await fetch('https://api.ipify.org?format=json');
-    const json = await resp.json();
-    return json.ip || 'Unknown IP';
-  } catch {
-    return 'Unknown IP';
-  }
-};
-
-// Creates a new contact
 export async function createContact(params) {
-  // console.log(`Attempting to create new contact`);
-
   return fetch(
     `${PROXY_URL}https://api.hubapi.com/contacts/v1/contact/?hapikey=${HAPIKEY}`,
     {
       method: 'POST',
       headers: {
+        // Authorization: `Bearer ${HUBSPOT_TOKEN}`,
         'Content-Type': 'application/json',
       },
       body: JSON.stringify(params),
@@ -37,25 +24,20 @@ export async function createContact(params) {
   );
 }
 
-// Adds a contact to the contact list
 export async function addToContactList(params) {
-  // console.log(`Adding contact to list`);
-
   return fetch(`${PROXY_URL + HUBSPOT_LIST_URL}/add?hapikey=${HAPIKEY}`, {
     method: 'POST',
     headers: {
-      // Authorization: `Bearer ${HUBSPOT_TOKEN}`,
       'Content-Type': 'application/json',
     },
     body: JSON.stringify(params),
   });
 }
 
-// Get a single contact by email
 export async function getContact(email) {
-  // console.log(`Getting contact details`);
-
   let datasetRequestDetails;
+  let status;
+
   await fetch(
     `${PROXY_URL}https://api.hubapi.com/contacts/v1/contact/email/${email}/profile?hapikey=${HAPIKEY}`,
     {
@@ -65,16 +47,21 @@ export async function getContact(email) {
       },
     }
   )
-    .then(response => response.json())
+    .then(response => {
+      status = response.status;
+      return response.json();
+    })
     .then(data => {
-      if (datasetRequestDetails !== undefined) {
+      if (data && data.properties.dataset_request_details) {
         datasetRequestDetails = data.properties.dataset_request_details.value;
       }
     });
-  return datasetRequestDetails;
+  return {
+    status,
+    datasetRequestDetails,
+  };
 }
 
-// Updates a contact by email
 export async function updateContact(email, params) {
   await fetch(
     `${PROXY_URL}https://api.hubapi.com/contacts/v1/contact/email/${email}/profile?hapikey=${HAPIKEY}`,
@@ -88,51 +75,21 @@ export async function updateContact(email, params) {
   );
 }
 
-// Might want to move this code into same file as github.js since they should be ran together anyway?
-export async function submitExperimentDataRequestHubspot(
-  accessionCode,
-  values
-) {
-  const ip = await getIP();
-  let newDetails = `Requested experiment ${accessionCode}\nPediatric cancer research: ${
-    values.pediatric_cancer
-  }\nPrimary approach: ${values.approach}\nAdditional notes: ${
-    values.comments
-  }\n${
-    values.email_updates
-      ? '(Wants email updates)'
-      : '(Does not want email updates)'
-  }\nIP: ${ip}`;
+// Checks if a contact exists and updates if so, if not then creates a new contact, and then adds that contact to the list
+export async function updateContactList(email, newDetails) {
+  let details = newDetails;
 
-  // Attempt to create a new contact
-  const response = await createContact({
-    properties: [
-      {
-        property: 'email',
-        value: values.email,
-      },
-      {
-        property: 'dataset_request_details',
-        value: newDetails,
-      },
-    ],
-  });
+  // Check if contact exists
+  const contactData = await getContact(email);
 
-  // If there is a conflict in creating the contact, then instead update that existing contact
-  if (response.status === 409) {
-    // console.log(`Contact ${values.email} already exists`);
-
-    // Get existing Dataset Request Details field from this contact
-    const oldDatasetRequestDetails = await getContact(values.email);
-
-    // If the existing contact already has this field filled in, then the new request details should be appended to the old data in the field
-    if (oldDatasetRequestDetails !== undefined) {
-      newDetails = `${oldDatasetRequestDetails}\n----------\n${newDetails}`;
-    }
-
-    // Update that contact with the new information
-    await updateContact(values.email, {
+  // Create a new contact email isn't found
+  if (contactData.status === 404) {
+    await createContact({
       properties: [
+        {
+          property: 'email',
+          value: email,
+        },
         {
           property: 'dataset_request_details',
           value: newDetails,
@@ -140,9 +97,58 @@ export async function submitExperimentDataRequestHubspot(
       ],
     });
   }
+  // Update existing contact otherwise
+  else {
+    const oldDatasetRequestDetails = contactData.datasetRequestDetails;
+
+    // If the existing contact already has this field filled in, then the new request details should be appended to the old data in the field
+    if (oldDatasetRequestDetails !== undefined) {
+      details = `${newDetails}\n----------\n${oldDatasetRequestDetails}`;
+    }
+
+    // Update that contact with the new information
+    await updateContact(email, {
+      properties: [
+        {
+          property: 'dataset_request_details',
+          value: details,
+        },
+      ],
+    });
+  }
 
   // Add that contact to the list
   await addToContactList({
-    emails: [values.email],
+    emails: [email],
   });
+}
+
+export async function submitSearchDataRequest(query, values) {
+  const newDetails = `Requested experiment(s) ${
+    values.accession_codes
+  } for search term "${query}"\nPediatric cancer research: ${
+    values.pediatric_cancer
+  }\nPrimary approach: ${values.approach}\n\nAdditional Notes:\n${
+    values.comments
+  }\n\n${
+    values.email_updates
+      ? '(Wants email updates)'
+      : '(Does not want email updates)'
+  }\nSubmitted ${new Date().toLocaleString()}`;
+
+  updateContactList(values.email, newDetails);
+}
+
+export async function submitExperimentDataRequest(accessionCode, values) {
+  const newDetails = `Requested experiment ${accessionCode}\nPediatric cancer research: ${
+    values.pediatric_cancer
+  }\nPrimary approach: ${values.approach}\n\nAdditional Notes:\n${
+    values.comments
+  }\n\n${
+    values.email_updates
+      ? '(Wants email updates)'
+      : '(Does not want email updates)'
+  }\nSubmitted ${new Date().toLocaleString()}`;
+
+  updateContactList(values.email, newDetails);
 }

--- a/src/common/hubspot.js
+++ b/src/common/hubspot.js
@@ -3,20 +3,15 @@
  */
 
 // ID for HubSpot list that contacts should be added to (currently goes to a test list)
-const LIST_ID = '1';
-const HUBSPOT_LIST_URL = `https://api.hubapi.com/contacts/v1/lists/${LIST_ID}`;
-
-// const HUBSPOT_TOKEN = process.env.HUBSPOT_TOKEN;
-const HAPIKEY = '8b29bb28-7ae7-4815-9975-2c05d0326b74'; // using personal api key for now will delete later
-const PROXY_URL = 'https://cors-anywhere.herokuapp.com/'; // idk if this is the best way to do this but this fixes the problem with CORS
+const LIST_ID = '1'; // this is a test list ID, change to actual list ID once done
+const { HUBSPOT_APIKEY } = process.env;
 
 export async function createContact(params) {
   return fetch(
-    `${PROXY_URL}https://api.hubapi.com/contacts/v1/contact/?hapikey=${HAPIKEY}`,
+    `https://api.hubapi.com/contacts/v1/contact/?hapikey=${HUBSPOT_APIKEY}`,
     {
       method: 'POST',
       headers: {
-        // Authorization: `Bearer ${HUBSPOT_TOKEN}`,
         'Content-Type': 'application/json',
       },
       body: JSON.stringify(params),
@@ -25,13 +20,16 @@ export async function createContact(params) {
 }
 
 export async function addToContactList(params) {
-  return fetch(`${PROXY_URL + HUBSPOT_LIST_URL}/add?hapikey=${HAPIKEY}`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(params),
-  });
+  return fetch(
+    `https://api.hubapi.com/contacts/v1/lists/${LIST_ID}/add?hapikey=${HUBSPOT_APIKEY}`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(params),
+    }
+  );
 }
 
 export async function getContact(email) {
@@ -39,7 +37,7 @@ export async function getContact(email) {
   let status;
 
   await fetch(
-    `${PROXY_URL}https://api.hubapi.com/contacts/v1/contact/email/${email}/profile?hapikey=${HAPIKEY}`,
+    `https://api.hubapi.com/contacts/v1/contact/email/${email}/profile?hapikey=${HUBSPOT_APIKEY}`,
     {
       method: 'GET',
       headers: {
@@ -52,8 +50,10 @@ export async function getContact(email) {
       return response.json();
     })
     .then(data => {
-      if (data && data.properties.dataset_request_details) {
-        datasetRequestDetails = data.properties.dataset_request_details.value;
+      if (data.status !== 'error') {
+        if (data.properties.dataset_request_details) {
+          datasetRequestDetails = data.properties.dataset_request_details.value;
+        }
       }
     });
   return {
@@ -64,7 +64,7 @@ export async function getContact(email) {
 
 export async function updateContact(email, params) {
   await fetch(
-    `${PROXY_URL}https://api.hubapi.com/contacts/v1/contact/email/${email}/profile?hapikey=${HAPIKEY}`,
+    `https://api.hubapi.com/contacts/v1/contact/email/${email}/profile?hapikey=${HUBSPOT_APIKEY}`,
     {
       method: 'POST',
       headers: {
@@ -118,7 +118,7 @@ export async function updateContactList(email, newDetails) {
   }
 
   // Add that contact to the list
-  await addToContactList({
+  return addToContactList({
     emails: [email],
   });
 }
@@ -136,7 +136,7 @@ export async function submitSearchDataRequest(query, values) {
       : '(Does not want email updates)'
   }\nSubmitted ${new Date().toLocaleString()}`;
 
-  updateContactList(values.email, newDetails);
+  return updateContactList(values.email, newDetails);
 }
 
 export async function submitExperimentDataRequest(accessionCode, values) {
@@ -150,5 +150,5 @@ export async function submitExperimentDataRequest(accessionCode, values) {
       : '(Does not want email updates)'
   }\nSubmitted ${new Date().toLocaleString()}`;
 
-  updateContactList(values.email, newDetails);
+  return updateContactList(values.email, newDetails);
 }

--- a/src/common/slack.js
+++ b/src/common/slack.js
@@ -4,7 +4,8 @@
 
 // btoa(webhook_url)
 const SLACK_HOOK_URL =
-  'aHR0cHM6Ly9ob29rcy5zbGFjay5jb20vc2VydmljZXMvVDYyR1g1UlFVL0JCUzUyVDc5OC9vbTBlMWplM0ZObTJuMk5hblFHZ0pSMW4=';
+  'aHR0cHM6Ly9ob29rcy5zbGFjay5jb20vc2VydmljZXMvVDYyR1g1UlFVL0JOOUpVNFBUNi92R3VCZHJLY2c2RXZmOGJmNmlHdmlJNzE=';
+// Actual webhook: 'aHR0cHM6Ly9ob29rcy5zbGFjay5jb20vc2VydmljZXMvVDYyR1g1UlFVL0JCUzUyVDc5OC9vbTBlMWplM0ZObTJuMk5hblFHZ0pSMW4=';
 
 // get IP
 const getIP = async () => {
@@ -78,7 +79,7 @@ export async function submitSearchDataRequest(query, values) {
   });
 }
 
-export async function submitExperimentDataRequest(accessionCode, values) {
+export async function submitExperimentDataRequestSlack(accessionCode, values) {
   const ip = await getIP();
   await postToSlack({
     attachments: [

--- a/src/common/slack.js
+++ b/src/common/slack.js
@@ -2,10 +2,7 @@
  * This file contains helper methods that post to the CCDL slack channel
  */
 
-// btoa(webhook_url)
-const SLACK_HOOK_URL =
-  'aHR0cHM6Ly9ob29rcy5zbGFjay5jb20vc2VydmljZXMvVDYyR1g1UlFVL0JOOUpVNFBUNi92R3VCZHJLY2c2RXZmOGJmNmlHdmlJNzE=';
-// Actual webhook: 'aHR0cHM6Ly9ob29rcy5zbGFjay5jb20vc2VydmljZXMvVDYyR1g1UlFVL0JCUzUyVDc5OC9vbTBlMWplM0ZObTJuMk5hblFHZ0pSMW4=';
+const { SLACK_HOOK_URL } = process.env;
 
 // get IP
 const getIP = async () => {
@@ -23,13 +20,13 @@ const getIP = async () => {
  * @param {object} params Slack webhooks params
  */
 export async function postToSlack(params) {
-  return fetch(atob(SLACK_HOOK_URL), {
+  return fetch(SLACK_HOOK_URL, {
     method: 'POST',
     body: JSON.stringify(params),
   });
 }
 
-export async function submitSearchDataRequest(query, values) {
+export async function submitSearchDataRequest(query, values, failedRequest) {
   const ip = await getIP();
   await postToSlack({
     attachments: [
@@ -71,7 +68,9 @@ export async function submitSearchDataRequest(query, values) {
               ]
             : []),
         ],
-        footer: `Refine.bio | ${ip} | ${navigator.userAgent}`,
+        footer: `Refine.bio | ${ip} | ${
+          navigator.userAgent
+        } | This message was sent because the request to ${failedRequest} failed`,
         footer_icon: 'https://s3.amazonaws.com/refinebio-email/logo-2x.png',
         ts: Date.now() / 1000, // unix time
       },
@@ -79,7 +78,11 @@ export async function submitSearchDataRequest(query, values) {
   });
 }
 
-export async function submitExperimentDataRequest(accessionCode, values) {
+export async function submitExperimentDataRequest(
+  accessionCode,
+  values,
+  failedRequest
+) {
   const ip = await getIP();
   await postToSlack({
     attachments: [
@@ -116,7 +119,9 @@ export async function submitExperimentDataRequest(accessionCode, values) {
               ]
             : []),
         ],
-        footer: `Refine.bio | ${ip} | ${navigator.userAgent}`,
+        footer: `Refine.bio | ${ip} | ${
+          navigator.userAgent
+        } | This message was sent because the request to ${failedRequest} failed`,
         footer_icon: 'https://s3.amazonaws.com/refinebio-email/logo-2x.png',
         ts: Date.now() / 1000, // unix time
       },

--- a/src/common/slack.js
+++ b/src/common/slack.js
@@ -2,7 +2,7 @@
  * This file contains helper methods that post to the CCDL slack channel
  */
 
-const { SLACK_HOOK_URL } = process.env;
+const SLACK_HOOK_URL = process.env.SLACK_HOOK_URL;
 
 // get IP
 const getIP = async () => {

--- a/src/common/slack.js
+++ b/src/common/slack.js
@@ -26,15 +26,16 @@ export async function postToSlack(params) {
   });
 }
 
-export async function submitSearchDataRequest(query, values, failedRequest) {
+export async function submitSearchDataRequest(values, failedRequest) {
   const ip = await getIP();
+
   await postToSlack({
     attachments: [
       {
-        fallback: `Missing data for search term '${query}'`,
+        fallback: `Missing data for search term '${values.query}'`,
         color: '#2eb886',
-        title: `Missing data for search term '${query}'`,
-        title_link: `https://www.refine.bio/search?q=${query}`,
+        title: `Missing data for search term '${values.query}'`,
+        title_link: `https://www.refine.bio/search?q=${values.query}`,
         fields: [
           {
             title: 'Accession Codes',
@@ -69,7 +70,7 @@ export async function submitSearchDataRequest(query, values, failedRequest) {
             : []),
         ],
         footer: `Refine.bio | ${ip} | ${
-          navigator.userAgent
+          values.navigatorUserAgent
         } | This message was sent because the request to ${failedRequest} failed`,
         footer_icon: 'https://s3.amazonaws.com/refinebio-email/logo-2x.png',
         ts: Date.now() / 1000, // unix time
@@ -78,19 +79,17 @@ export async function submitSearchDataRequest(query, values, failedRequest) {
   });
 }
 
-export async function submitExperimentDataRequest(
-  accessionCode,
-  values,
-  failedRequest
-) {
+export async function submitExperimentDataRequest(values, failedRequest) {
   const ip = await getIP();
   await postToSlack({
     attachments: [
       {
-        fallback: `${accessionCode} Experiment Requested`,
+        fallback: `${values.accession_codes} Experiment Requested`,
         color: '#2eb886',
-        title: `${accessionCode} Experiment Requested`,
-        title_link: `https://www.refine.bio/experiments/${accessionCode}`,
+        title: `${values.accession_codes} Experiment Requested`,
+        title_link: `https://www.refine.bio/experiments/${
+          values.accession_codes
+        }`,
         fields: [
           {
             title: 'Pediatric Cancer Research',
@@ -120,7 +119,7 @@ export async function submitExperimentDataRequest(
             : []),
         ],
         footer: `Refine.bio | ${ip} | ${
-          navigator.userAgent
+          values.navigatorUserAgent
         } | This message was sent because the request to ${failedRequest} failed`,
         footer_icon: 'https://s3.amazonaws.com/refinebio-email/logo-2x.png',
         ts: Date.now() / 1000, // unix time

--- a/src/common/slack.js
+++ b/src/common/slack.js
@@ -79,7 +79,7 @@ export async function submitSearchDataRequest(query, values) {
   });
 }
 
-export async function submitExperimentDataRequestSlack(accessionCode, values) {
+export async function submitExperimentDataRequest(accessionCode, values) {
   const ip = await getIP();
   await postToSlack({
     attachments: [

--- a/src/pages/experiments/RequestExperimentButton.js
+++ b/src/pages/experiments/RequestExperimentButton.js
@@ -42,7 +42,6 @@ export default function RequestExperimentButton({ accessionCode }) {
                 accessionCode
               );
 
-              // If authorization fails, then send to Slack instead (should probably change to != 200 later)
               if (response.status !== 200) {
                 // console.log(`Failed to connect to GitHub (error ${response.status})`);
                 await submitExperimentDataRequestSlack(accessionCode, values);

--- a/src/pages/experiments/RequestExperimentButton.js
+++ b/src/pages/experiments/RequestExperimentButton.js
@@ -4,9 +4,7 @@ import { useLocalStorage } from '../../common/hooks';
 import Button from '../../components/Button';
 import PageModal from '../../components/Modal/PageModal';
 import RequestDataForm from '../../components/RequestDataForm';
-import { submitExperimentDataRequest as slackRequest } from '../../common/slack';
-import { submitExperimentDataRequest as githubRequest } from '../../common/github';
-import { submitExperimentDataRequest as hubspotRequest } from '../../common/hubspot';
+import { dataRequest } from '../../api/requests';
 
 export default function RequestExperimentButton({ accessionCode }) {
   const [requestOpen, setRequestOpen] = React.useState(false);
@@ -37,21 +35,13 @@ export default function RequestExperimentButton({ accessionCode }) {
             useMissingDataImage={false}
             onClose={() => setRequestOpen(false)}
             onSubmit={async values => {
-              // 1. create GitHub issue for refinebio repo
-              const response = await githubRequest(accessionCode);
+              // 1. send experiment request, which takes the accession code and values from the form
+              dataRequest({ accessionCode, values });
 
-              // Send to slack instead if GitHub request failed
-              if (!response.ok) {
-                await slackRequest(accessionCode, values);
-              }
-
-              // 2. add contact to HubSpot list
-              await hubspotRequest(accessionCode, values);
-
-              // 3. mark experiment as requested in local storage
+              // 2. mark experiment as requested in local storage
               setRequestedExperiments([...requestedExperiments, accessionCode]);
 
-              // 4. close page
+              // 3. close page
               setRequestOpen(false);
             }}
             renderHeader={() => (

--- a/src/pages/experiments/RequestExperimentButton.js
+++ b/src/pages/experiments/RequestExperimentButton.js
@@ -4,9 +4,9 @@ import { useLocalStorage } from '../../common/hooks';
 import Button from '../../components/Button';
 import PageModal from '../../components/Modal/PageModal';
 import RequestDataForm from '../../components/RequestDataForm';
-import { submitExperimentDataRequestSlack } from '../../common/slack';
-import { submitExperimentDataRequestGithub } from '../../common/github';
-import { submitExperimentDataRequestHubspot } from '../../common/hubspot';
+import { submitExperimentDataRequest as slackRequest } from '../../common/slack';
+import { submitExperimentDataRequest as githubRequest } from '../../common/github';
+import { submitExperimentDataRequest as hubspotRequest } from '../../common/hubspot';
 
 export default function RequestExperimentButton({ accessionCode }) {
   const [requestOpen, setRequestOpen] = React.useState(false);
@@ -38,17 +38,15 @@ export default function RequestExperimentButton({ accessionCode }) {
             onClose={() => setRequestOpen(false)}
             onSubmit={async values => {
               // 1. create GitHub issue for refinebio repo
-              const response = await submitExperimentDataRequestGithub(
-                accessionCode
-              );
+              const response = await githubRequest(accessionCode);
 
-              if (response.status !== 200) {
-                // console.log(`Failed to connect to GitHub (error ${response.status})`);
-                await submitExperimentDataRequestSlack(accessionCode, values);
+              // Send to slack instead if GitHub request failed
+              if (!response.ok) {
+                await slackRequest(accessionCode, values);
               }
 
               // 2. add contact to HubSpot list
-              await submitExperimentDataRequestHubspot(accessionCode, values);
+              await hubspotRequest(accessionCode, values);
 
               // 3. mark experiment as requested in local storage
               setRequestedExperiments([...requestedExperiments, accessionCode]);

--- a/src/pages/experiments/RequestExperimentButton.js
+++ b/src/pages/experiments/RequestExperimentButton.js
@@ -35,8 +35,11 @@ export default function RequestExperimentButton({ accessionCode }) {
             useMissingDataImage={false}
             onClose={() => setRequestOpen(false)}
             onSubmit={async values => {
-              // 1. send experiment request, which takes the accession code and values from the form
-              dataRequest({ accessionCode, values });
+              // 1. send experiment request
+              const requestValues = values;
+              requestValues.accession_codes = accessionCode;
+              requestValues.request_type = 'experiment';
+              dataRequest({ requestValues });
 
               // 2. mark experiment as requested in local storage
               setRequestedExperiments([...requestedExperiments, accessionCode]);

--- a/src/pages/search/RequestSearchButton.js
+++ b/src/pages/search/RequestSearchButton.js
@@ -3,7 +3,9 @@ import { connect } from 'react-redux';
 import { Field } from 'formik';
 import { push } from '../../state/routerActions';
 import Button from '../../components/Button';
-import { submitSearchDataRequest } from '../../common/slack';
+import { submitSearchDataRequest as slackRequest } from '../../common/slack';
+import { submitSearchDataRequest as githubRequest } from '../../common/github';
+import { submitSearchDataRequest as hubspotRequest } from '../../common/hubspot';
 import PageModal from '../../components/Modal/PageModal';
 import RequestDataForm from '../../components/RequestDataForm';
 
@@ -26,10 +28,17 @@ let RequestSearchButton = ({ query, push }) => {
           <RequestDataForm
             onClose={() => setRequestOpen(false)}
             onSubmit={async values => {
-              // 1. report to slack
-              await submitSearchDataRequest(queryParam, values);
+              // 1. report to GitHub
+              const response = await githubRequest(queryParam, values);
 
-              // 2. redirect to landing page with notification
+              if (!response.ok) {
+                await slackRequest(queryParam, values);
+              }
+
+              // 2. add contact to HubSpot list
+              await hubspotRequest(queryParam, values);
+
+              // 3. redirect to landing page with notification
               push({
                 pathname: '/',
                 state: {

--- a/src/pages/search/RequestSearchButton.js
+++ b/src/pages/search/RequestSearchButton.js
@@ -3,11 +3,9 @@ import { connect } from 'react-redux';
 import { Field } from 'formik';
 import { push } from '../../state/routerActions';
 import Button from '../../components/Button';
-import { submitSearchDataRequest as slackRequest } from '../../common/slack';
-import { submitSearchDataRequest as githubRequest } from '../../common/github';
-import { submitSearchDataRequest as hubspotRequest } from '../../common/hubspot';
 import PageModal from '../../components/Modal/PageModal';
 import RequestDataForm from '../../components/RequestDataForm';
+import { dataRequest } from '../../api/requests';
 
 let RequestSearchButton = ({ query, push }) => {
   const [requestOpen, setRequestOpen] = React.useState(false);
@@ -28,17 +26,10 @@ let RequestSearchButton = ({ query, push }) => {
           <RequestDataForm
             onClose={() => setRequestOpen(false)}
             onSubmit={async values => {
-              // 1. report to GitHub
-              const response = await githubRequest(queryParam, values);
+              // 1. send experiment request, which takes the search query and the values from the form
+              dataRequest({ query: queryParam, values });
 
-              if (!response.ok) {
-                await slackRequest(queryParam, values);
-              }
-
-              // 2. add contact to HubSpot list
-              await hubspotRequest(queryParam, values);
-
-              // 3. redirect to landing page with notification
+              // 2. redirect to landing page with notification
               push({
                 pathname: '/',
                 state: {

--- a/src/pages/search/RequestSearchButton.js
+++ b/src/pages/search/RequestSearchButton.js
@@ -27,7 +27,10 @@ let RequestSearchButton = ({ query, push }) => {
             onClose={() => setRequestOpen(false)}
             onSubmit={async values => {
               // 1. send experiment request, which takes the search query and the values from the form
-              dataRequest({ query: queryParam, values });
+              const requestValues = values;
+              requestValues.query = queryParam;
+              requestValues.request_type = 'search';
+              dataRequest({ requestValues });
 
               // 2. redirect to landing page with notification
               push({


### PR DESCRIPTION
## Issue Number

[#1738](https://app.zenhub.com/workspaces/refinebio-5c92300a9d1bd30b8d3101f2/issues/alexslemonade/refinebio/1738)

## Purpose/Implementation Notes

Experiment data requests are added as issues to GitHub, and those contacts are added to HubSpot. Right now still using test repo and HubSpot list. I couldn't find a way to change the internal name of a custom field in HubSpot but it seems that it's automatically set as `dataset_request_details` for a custom field called Dataset Request Details, so this should work with the actual contact list as long as it is named the same.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

* [ ] Bugfix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

GitHub token, HubSpot API key, and Slack webhook URL should be env variables.

## Functional tests

I've made a [test repo](https://github.com/BEW111/testrepo/issues) which the dataset requests are sent to, and a test list on HubSpot for new contacts. If a GitHub or HubSpot request fails then it is instead sent to Slack. As of right now I think the only way the HubSpot request would fail is if an invalid email is entered that the refine.bio form doesn't recognize as invalid but that HubSpot does deem as invalid.

## Checklist

_Put an `x` in the boxes that apply._

* [x] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
* [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

<img width="1603" alt="hubspottest" src="https://user-images.githubusercontent.com/30025868/84942320-9e9c5680-b0b0-11ea-9bf8-8924eea974a2.png">