### PR TITLE
Added alternate accession codes to experiment pages

### DIFF
--- a/src/common/helpers.js
+++ b/src/common/helpers.js
@@ -382,3 +382,18 @@ export const subscribeToMailingList = async email => {
     throw new EmailSubscriptionError(email);
   }
 };
+
+/**
+ * Returns the external accession code URL for a given accession code
+ */
+export function getUrlForCode(code) {
+  let mainUrl = '';
+  if (code.startsWith('GSE')) {
+    mainUrl = 'https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=';
+  } else if (code.startsWith('RP', 1)) {
+    mainUrl = 'https://www.ebi.ac.uk/ena/data/view/';
+  } else if (code.startsWith('E-')) {
+    mainUrl = 'https://www.ebi.ac.uk/arrayexpress/experiments/';
+  }
+  return mainUrl + code;
+}

--- a/src/pages/experiments/index.js
+++ b/src/pages/experiments/index.js
@@ -12,6 +12,7 @@ import {
   formatSentenceCase,
   truncateOnWord,
   maxTableWidth,
+  getUrlForCode,
 } from '../../common/helpers';
 
 import AccessionIcon from '../../common/icons/accession.svg';
@@ -281,6 +282,18 @@ let Experiment = ({
                 </a>
               </ExperimentHeaderRow>
             )}
+            <ExperimentHeaderRow label="Alternate Accession IDs">
+              {(experiment.alternate_accession_code && (
+                <a
+                  href={getUrlForCode(experiment.alternate_accession_code)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="link"
+                >
+                  <HText>{experiment.alternate_accession_code}</HText>
+                </a>
+              )) || <i className="experiment__not-provided">None</i>}
+            </ExperimentHeaderRow>
           </div>
         </div>
       </div>

--- a/src/pages/search/Result/index.js
+++ b/src/pages/search/Result/index.js
@@ -7,6 +7,7 @@ import {
   formatSentenceCase,
   getMetadataFields,
   formatPlatformName,
+  getUrlForCode,
 } from '../../../common/helpers';
 import DataSetSampleActions from '../../../components/DataSetSampleActions';
 import * as routes from '../../../routes';
@@ -121,6 +122,21 @@ const Result = ({ result, query }) => {
             <HText>{result.publication_title}</HText>
           ) : (
             <i className="result__not-provided">No associated publication</i>
+          )}
+        </p>
+        <h3> Alternate Accession IDs </h3>
+        <p className="result__paragraph">
+          {result.alternate_accession_code ? (
+            <a
+              href={getUrlForCode(result.alternate_accession_code)}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="link"
+            >
+              <HText>{result.alternate_accession_code}</HText>
+            </a>
+          ) : (
+            <i className="result__not-provided">None</i>
           )}
         </p>
         <h3>Sample Metadata Fields</h3>


### PR DESCRIPTION
## Issue Number

[#871](https://github.com/AlexsLemonade/refinebio-frontend/issues/871)

## Purpose/Implementation Notes

The alternate accession code for an experiment is displayed on the search results page and experiment detail page. There's only one alternate accession code per experiment right now so the code is dependent on that fact. Also I put a function `getUrlForCode` in `helpers.js` but I can always move it if there's a better place to have that.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

* [ ] Bugfix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

Since this is dependent on the Experiment Detail endpoint having the `alternate_accession_code` field, I've merged [that change](https://github.com/AlexsLemonade/refinebio/pull/2343) into the backend but tested this change using the locally hosted API, which works for the experiments on there.

## Checklist

_Put an `x` in the boxes that apply._

* [x] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
* [x] Any dependent changes have been merged and published in downstream modules
