### PR TITLE
Fix download now button

### DIFF
--- a/src/components/DatasetDownloadOptionsForm.js
+++ b/src/components/DatasetDownloadOptionsForm.js
@@ -316,6 +316,7 @@ const DatasetDownloadOptionsFormComponent = ({
         const startedDataset = await updateDataSetOptions(
           {
             ...updatedDataset,
+            email_address: values.email_address,
             start: true,
           },
           tokenId


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio-frontend/issues/909

## Purpose/Implementation Notes

The API is expecting an `email_address` parameter that wasn't passed to the last request because it is write-only but the last request was just reading the response from the previous request.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

* [ ] Bugfix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

It works now when running my local build against prod.

## Checklist

_Put an `x` in the boxes that apply._

* [ ] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
* [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

Please attach any screenshots that illustrate these changes.
