### PR TITLE
Fix QN skipped typos

### DIFF
--- a/src/pages/dataset/DatasetDetails.js
+++ b/src/pages/dataset/DatasetDetails.js
@@ -59,7 +59,7 @@ function DatasetRegenerateOptions({ dataSet, regenerateDataSet }) {
       </div>
       {!dataSet.quantile_normalize && (
         <div className="downloads__file-modifier">
-          Quantile Normailzation Skipped for RNA-seeq samples
+          Quantile Normalization Skipped for RNA-seq samples
         </div>
       )}
       <div className="downloads__file-modifier">


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

`Normalization` and `RNA-seq` both had typos on the dataset detail page when someone skips QN for RNA-seq, so I fixed the typos.

