### PR TITLE
Include Ensembl release and division for RNA-seq samples

### DIFF
--- a/src/components/SamplesTable/ProcessingInformation/ProcessorVersion.js
+++ b/src/components/SamplesTable/ProcessingInformation/ProcessorVersion.js
@@ -43,6 +43,8 @@ export default class ProcessorVersion extends React.Component {
           {results.map(({ processor }) => this._renderProcessor(processor))}
 
           {this._renderGnomeVersion()}
+
+          {this._renderDatabaseInfo()}
         </Accordion>
       </React.Fragment>
     );
@@ -83,6 +85,45 @@ export default class ProcessorVersion extends React.Component {
                   versions={{
                     'genome build':
                       salmonProcessedResult.organism_index.assembly_name,
+                  }}
+                />
+              </tbody>
+            </table>
+          </div>
+        )}
+      />
+    );
+  }
+
+  _renderDatabaseInfo() {
+    const salmonProcessedResult = this.props.results.find(
+      result => result.processor.name === 'Salmon Quant'
+    );
+    if (
+      !salmonProcessedResult ||
+      !salmonProcessedResult.organism_index ||
+      !salmonProcessedResult.organism_index.source_version
+    ) {
+      return null;
+    }
+    return (
+      <AccordionItem
+        title={() => (
+          <div>
+            <b>Database Info</b>
+
+            <table>
+              <tbody>
+                <VersionTable
+                  versions={{
+                    'database name':
+                      salmonProcessedResult.organism_index.database_name,
+                  }}
+                />
+                <VersionTable
+                  versions={{
+                    'release version':
+                      salmonProcessedResult.organism_index.release_version,
                   }}
                 />
               </tbody>

--- a/src/components/SamplesTable/ProcessingInformation/ProcessorVersion.js
+++ b/src/components/SamplesTable/ProcessingInformation/ProcessorVersion.js
@@ -43,8 +43,6 @@ export default class ProcessorVersion extends React.Component {
           {results.map(({ processor }) => this._renderProcessor(processor))}
 
           {this._renderGnomeVersion()}
-
-          {this._renderDatabaseInfo()}
         </Accordion>
       </React.Fragment>
     );
@@ -87,33 +85,6 @@ export default class ProcessorVersion extends React.Component {
                       salmonProcessedResult.organism_index.assembly_name,
                   }}
                 />
-              </tbody>
-            </table>
-          </div>
-        )}
-      />
-    );
-  }
-
-  _renderDatabaseInfo() {
-    const salmonProcessedResult = this.props.results.find(
-      result => result.processor.name === 'Salmon Quant'
-    );
-    if (
-      !salmonProcessedResult ||
-      !salmonProcessedResult.organism_index ||
-      !salmonProcessedResult.organism_index.source_version
-    ) {
-      return null;
-    }
-    return (
-      <AccordionItem
-        title={() => (
-          <div>
-            <b>Database Info</b>
-
-            <table>
-              <tbody>
                 <VersionTable
                   versions={{
                     'database name':


### PR DESCRIPTION
## Issue Number

#923 

## Purpose/Implementation Notes

This is dependent on AlexsLemonade/refinebio/pull/2527, since it uses the `release_version` and `database_name` fields of the transcriptome indices. The processing info for a transcriptome index now shows those two fields.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

* [ ] Bugfix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

I tested this with the current API (not the changes from [#2527](https://github.com/AlexsLemonade/refinebio/pull/2527)) and `source_version` shows up, and the only difference between that and the new field names is the names themselves so it should show up as long as they are in the database.

## Checklist

_Put an `x` in the boxes that apply._

* [x] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
* [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

Right now this doesn't have the entries since those would come from the changes in [#2527](https://github.com/AlexsLemonade/refinebio/pull/2527)

<img width="819" alt="Screen Shot 2020-08-31 at 12 34 26 PM" src="https://user-images.githubusercontent.com/30025868/91743821-6cb27080-eb86-11ea-9be5-7543deee191d.png">
