### PR TITLE
set now@19.2.0 for deploys

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install now
-        run: yarn global add now
+        run: yarn global add now@19.2.0
 
       - name: Deploy to prod
         run: $(yarn global bin)/now  --confirm --prod --token $ZEIT_TOKEN --local-config now.json --scope ccdl

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install now
-        run: yarn global add now
+        run: yarn global add now@19.2.0
 
       - name: Deploy to staging
         run: $(yarn global bin)/now  --confirm --prod --token $ZEIT_TOKEN --local-config now.staging.json --scope ccdl


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

Deploys with github actions arent working with version 20 of now so instead of installing the latest use the most recent that complies with our current configs. ie 19.2.0 - This occurred on the resources portal and is something we should revisit in the future.

## Types of changes

* [x] Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

* [x] Lint and unit tests pass locally with my changes
