### PR TITLE
change email in footer and dataset header

### DIFF
--- a/src/components/Footer/index.js
+++ b/src/components/Footer/index.js
@@ -113,7 +113,7 @@ const Footer = () => (
       <Link href="/terms" as="/terms">
         <a className="footer__link">Terms of Use</a>
       </Link>
-      <a className="footer__link" href="mailto:ccdl@alexslemonade.org">
+      <a className="footer__link" href="mailto:requests@ccdatalab.org">
         Contact
       </a>
       {apiData.version && apiData.apiVersion && (

--- a/src/pages/dataset/DataSetPageHeader.js
+++ b/src/pages/dataset/DataSetPageHeader.js
@@ -64,8 +64,8 @@ const DataSetErrorDownloading = ({ dataSet }) => {
             </p>
             <p>
               Please contact{' '}
-              <a href="mailto:ccdl@alexslemonade.org" className="link">
-                ccdl@alexslemonade.org
+              <a href="mailto:requests@ccdatalab.org" className="link">
+                requests@ccdatalab.org
               </a>
               {dataSet.failure_reason && (
                 <span>


### PR DESCRIPTION
## Issue Number

#931 

## Purpose/Implementation Notes

Replace the email address displayed/linked to on the frontend with `requests@ccdatalab.org` so that multiple people can see the incoming emails and respond.

Don't replace the email in places where questions about things like the terms & conditions would be sent.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

[x] Bugfix (non-breaking change which fixes an issue)
[ ] New feature (non-breaking change which adds functionality)
[ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

Built and ran locally to see that the email was properly replaced.

## Checklist

_Put an `x` in the boxes that apply._

* [ ] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
* [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

When hovering over the `Contact` button in the footer, the link goes to the new email.
![image](https://user-images.githubusercontent.com/52019096/111796228-5a87ed80-889e-11eb-9239-fd72db7fe3f4.png)

not sure how to purposefully mess up a dataset so that the `DataSetErrorDownloading` component gets rendered to the screen.

