### PR TITLE
Fix #956

### DIFF
--- a/src/pages/experiments/Experiment.scss
+++ b/src/pages/experiments/Experiment.scss
@@ -90,10 +90,7 @@
   &__stats-icon {
     height: 24px;
     margin-right: 8px;
-
     user-select: none;
-    -moz-user-select: none;
-    -webkit-user-select: none;
   }
 
   &__source-database {

--- a/src/pages/experiments/Experiment.scss
+++ b/src/pages/experiments/Experiment.scss
@@ -90,6 +90,10 @@
   &__stats-icon {
     height: 24px;
     margin-right: 8px;
+
+    user-select: none;
+    -moz-user-select: none;
+    -webkit-user-select: none;
   }
 
   &__source-database {

--- a/src/pages/search/Result/Result.scss
+++ b/src/pages/search/Result/Result.scss
@@ -82,10 +82,7 @@
   &__icon {
     margin-right: 5px;
     height: 24px;
-
     user-select: none;
-    -moz-user-select: none;
-    -webkit-user-select: none;
   }
 
   &__stat {

--- a/src/pages/search/Result/Result.scss
+++ b/src/pages/search/Result/Result.scss
@@ -82,6 +82,10 @@
   &__icon {
     margin-right: 5px;
     height: 24px;
+
+    user-select: none;
+    -moz-user-select: none;
+    -webkit-user-select: none;
   }
 
   &__stat {


### PR DESCRIPTION
## Issue Number

Fixes https://github.com/AlexsLemonade/refinebio-frontend/issues/956

## Purpose/Implementation Notes

Adds `[prefix-]user-select: none` to icons on the search page and the experiment detail page to prevent accidentally copying the icon's alt text when trying to copy the text next to the icon.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

* [x] Bugfix (non-breaking change which fixes an issue)

## Functional tests

I ran the frontend locally and verified that this fixes the issue

## Checklist

_Put an `x` in the boxes that apply._

* [x] Lint and unit tests pass locally with my changes
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] I have added necessary documentation (if appropriate)
* [x] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A just an interactive change