### PR TITLE
946 unprocessed datasets download

### DIFF
--- a/src/pages/dataset/DataSetPageHeader.js
+++ b/src/pages/dataset/DataSetPageHeader.js
@@ -130,75 +130,68 @@ function DataSetProcessing({ emailAddress, dataSet }) {
   );
 }
 
-class DataSetReady extends React.Component {
-  state = {
-    agreedToTerms: false,
+let DataSetReady = ({ dataSet, createToken, hasToken }) => {
+  const [agreedToTerms, setAgreedToTerms] = React.useState(false);
+  const handleAgreedToTerms = () => {
+    setAgreedToTerms(!agreedToTerms);
   };
 
-  handleAgreedToTerms = () => {
-    this.setState(state => ({ agreedToTerms: !state.agreedToTerms }));
-  };
-
-  handleSubmit = async () => {
-    if (!this.props.hasToken) {
+  const handleSubmit = async () => {
+    if (!hasToken) {
       // if the current user doesn't has a valid token, we have to generate it
       // and request the dataset data again to get the `download_url`
-      const token = await this.props.createToken();
-      const dataSet = await getDataSet(this.props.dataSet.id, token);
+      const token = await createToken();
+      const dataSet = await getDataSet(dataSet.id, token);
       window.location.href = dataSet.download_url;
     } else {
       // otherwise we should have gotten the download url when the original
       // data was requested
-      window.location.href = this.props.dataSet.download_url;
+      window.location.href = dataSet.download_url;
     }
   };
 
-  render() {
-    return (
-      <>
-        <div className="dataset__container">
-          <div className="dataset__message">
-            <div className="dataset__way-container">
-              <div className="dataset__processed-text">
-                <h1>Your dataset is ready for download!</h1>
+  return (
+    <>
+      <div className="dataset__container">
+        <div className="dataset__message">
+          <div className="dataset__way-container">
+            <div className="dataset__processed-text">
+              <h1>Your dataset is ready for download!</h1>
 
-                {!!this.props.dataSet.size_in_bytes && (
-                  <div className="mb-1">
-                    Download size:{' '}
-                    {formatBytes(this.props.dataSet.size_in_bytes)}
-                  </div>
+              {!!dataSet.size_in_bytes && (
+                <div className="mb-1">
+                  Download size: {formatBytes(dataSet.size_in_bytes)}
+                </div>
+              )}
+
+              <div className="dataset__way-container">
+                {!hasToken && (
+                  <TermsOfUse
+                    agreedToTerms={agreedToTerms}
+                    handleToggle={handleAgreedToTerms}
+                  />
                 )}
 
-                <div className="dataset__way-container">
-                  {!this.props.hasToken && (
-                    <TermsOfUse
-                      agreedToTerms={this.state.agreedToTerms}
-                      handleToggle={this.handleAgreedToTerms}
-                    />
-                  )}
-
-                  <Button
-                    onClick={this.handleSubmit}
-                    isDisabled={
-                      !this.state.agreedToTerms && !this.props.hasToken
-                    }
-                  >
-                    Download Now
-                  </Button>
-                </div>
+                <Button
+                  onClick={handleSubmit}
+                  isDisabled={!agreedToTerms && !hasToken}
+                >
+                  Download Now
+                </Button>
               </div>
+            </div>
 
-              <div className="dataset__way-image">
-                <img src={DownloadImage} alt="" />
-              </div>
+            <div className="dataset__way-image">
+              <img src={DownloadImage} alt="" />
             </div>
           </div>
         </div>
-        <DataSetNextSteps dataSet={this.props.dataSet} />
-      </>
-    );
-  }
-}
+      </div>
+      <DataSetNextSteps dataSet={dataSet} />
+    </>
+  );
+};
+
 DataSetReady = connect(({ token }) => ({ hasToken: !!token }), {
   createToken,
 })(DataSetReady);

--- a/src/pages/dataset/DatasetDetails.js
+++ b/src/pages/dataset/DatasetDetails.js
@@ -12,12 +12,12 @@ import DownloadOptionsForm, {
   getTransformationOptionFromName,
 } from '../download/DownloadOptionsForm';
 
-export default function DatasetDetails({ dataSet }) {
+export default function DatasetDetails({ dataSet, showRegenerate = true }) {
   return (
     <div>
       <h2>Download Files Summary</h2>
 
-      <DatasetRegenerateOptions dataSet={dataSet} />
+      {showRegenerate && <DatasetRegenerateOptions dataSet={dataSet} />}
 
       <DownloadFileSummary dataSet={dataSet} />
       <DownloadDatasetSummary dataSet={dataSet} />

--- a/src/pages/dataset/DatasetDetails.js
+++ b/src/pages/dataset/DatasetDetails.js
@@ -72,9 +72,6 @@ function DatasetRegenerateOptions({ dataSet, regenerateDataSet }) {
     </div>
   );
 }
-DatasetRegenerateOptions = connect(
-  null,
-  {
-    regenerateDataSet,
-  }
-)(DatasetRegenerateOptions);
+DatasetRegenerateOptions = connect(null, {
+  regenerateDataSet,
+})(DatasetRegenerateOptions);

--- a/src/pages/dataset/index.js
+++ b/src/pages/dataset/index.js
@@ -60,6 +60,7 @@ export default function DataSet() {
       {({ dataSet, isLoading, hasError: requestHasError }) => {
         if (isLoading) return <Spinner />;
         if (requestHasError) return <NoMatch />;
+
         const showDownloadButton = !(
           dataSet.is_processing || dataSet.is_processed
         );
@@ -73,20 +74,25 @@ export default function DataSet() {
             />
             <div className="downloads__bar">
               <div className="flex-row">
-                <ShareDatasetButton dataSet={dataSet} />
-                {showDownloadButton && (
-                  // if it is not processed
-                  // allow the user to download the dataset
-                  // otherwise use the regenerate dataset flow
-                  <DownloadDataSetButtonModal
-                    shared={shared}
-                    dataSet={dataSet}
-                  />
-                )}
                 <MoveToDatasetButtonModal dataSet={dataSet} />
+                <div className="downloads__bar__share-download">
+                  <ShareDatasetButton dataSet={dataSet} />
+                  {showDownloadButton && (
+                    // if it is not processed
+                    // allow the user to download the dataset
+                    // otherwise use the regenerate dataset flow
+                    <DownloadDataSetButtonModal
+                      shared={shared}
+                      dataSet={dataSet}
+                    />
+                  )}
+                </div>
               </div>
             </div>
-            <DatasetDetails dataSet={dataSet} />
+            <DatasetDetails
+              dataSet={dataSet}
+              showRegenerate={!showDownloadButton}
+            />
           </div>
         );
       }}

--- a/src/pages/dataset/index.js
+++ b/src/pages/dataset/index.js
@@ -4,8 +4,16 @@ import Link from 'next/link';
 import { Formik, Field } from 'formik';
 import { IoIosWarning } from 'react-icons/io';
 import { useRouter } from 'next/router';
+import dynamic from 'next/dynamic';
 
-import { ShareDatasetButton } from '../download/DownloadBar';
+import {
+  DatasetDownloadOptionsForm,
+  AggreationOptions,
+  TransformationOptions,
+  AdvancedOptions,
+  EmailAddressOptions,
+  SubmitDatasetOptionsForm,
+} from '../../components/DatasetDownloadOptionsForm';
 import DownloadStart from '../download/DownloadStart/DownloadStart';
 import Spinner from '../../components/Spinner';
 import NoMatch from '../../components/NoMatch';
@@ -21,6 +29,13 @@ import { push } from '../../state/routerActions';
 import { RadioField } from '../../components/Radio';
 import DatasetDetails from './DatasetDetails';
 
+const ShareDatasetButton = dynamic(
+  () => import('../download/DownloadBar').then(mod => mod.ShareDatasetButton),
+  {
+    ssr: false,
+  }
+);
+
 /**
  * Dataset page, has 3 states that correspond with the states on the backend
  * - Processing: The download file is being created
@@ -30,8 +45,10 @@ import DatasetDetails from './DatasetDetails';
  */
 export default function DataSet() {
   const {
-    query: { dataSetId, regenerate, emailAddress, hasError },
+    query: { dataSetId, regenerate, emailAddress, hasError, ref },
   } = useRouter();
+
+  const shared = ref === 'share';
 
   // Check if the user arrived here and wants to regenerate the current page.
   if (regenerate) {
@@ -43,6 +60,9 @@ export default function DataSet() {
       {({ dataSet, isLoading, hasError: requestHasError }) => {
         if (isLoading) return <Spinner />;
         if (requestHasError) return <NoMatch />;
+        const showDownloadButton = !(
+          dataSet.is_processing || dataSet.is_processed
+        );
 
         return (
           <div>
@@ -54,7 +74,15 @@ export default function DataSet() {
             <div className="downloads__bar">
               <div className="flex-row">
                 <ShareDatasetButton dataSet={dataSet} />
-
+                {showDownloadButton && (
+                  // if it is not processed
+                  // allow the user to download the dataset
+                  // otherwise use the regenerate dataset flow
+                  <DownloadDataSetButtonModal
+                    shared={shared}
+                    dataSet={dataSet}
+                  />
+                )}
                 <MoveToDatasetButtonModal dataSet={dataSet} />
               </div>
             </div>
@@ -65,6 +93,80 @@ export default function DataSet() {
     </DataSetLoader>
   );
 }
+
+// button that shows download options on shared datasets
+let DownloadDataSetButtonModal = ({
+  shared = false,
+  dataSet: sharedDataSet,
+}) => {
+  const dataSet = { ...sharedDataSet };
+
+  // if shared delete the id so the form will create a new dataset copy
+  if (shared) {
+    delete dataSet.id;
+  }
+
+  return (
+    <ModalManager
+      component={showModal => (
+        <Button text="Download Dataset" onClick={showModal} />
+      )}
+      modalProps={{ center: true, className: 'modify-dataset-modal' }}
+    >
+      {({ hideModal }) => (
+        <>
+          <DatasetDownloadOptionsForm
+            dataset={dataSet}
+            setDataset={newDataset => {
+              hideModal();
+              window.location = `/dataset/${newDataset.id}`;
+            }}
+            classPrefix="download-experiment"
+            actionText="Start Processing"
+            advancedOptions
+            startDownload
+          >
+            <div className="flex-row mb-1">
+              <p className="emphasis">Download Options:</p>
+            </div>
+            {shared && (
+              <div className="flex-row mb-1">
+                <p className="emphasis">
+                  Processing this dataset will not affect "My Dataset".
+                </p>
+              </div>
+            )}
+
+            <div className="flex-row mb-1">
+              <AggreationOptions />
+            </div>
+            <div className="flex-row mb-1">
+              <TransformationOptions />
+            </div>
+            <div className="flex-row mb-1">
+              <AdvancedOptions />
+            </div>
+            <div className="flex-row mb-2">
+              <p className="emphasis mb-1">
+                Putting the download files together takes about 10-20 minutes.
+                Enter your email and we will send you the download link once
+                your files are ready.
+              </p>
+              <EmailAddressOptions />
+            </div>
+            <div className="flex-row">
+              <SubmitDatasetOptionsForm />
+            </div>
+          </DatasetDownloadOptionsForm>
+        </>
+      )}
+    </ModalManager>
+  );
+};
+
+DownloadDataSetButtonModal = connect(null, {
+  push,
+})(DownloadDataSetButtonModal);
 
 function MoveToDatasetButtonModal({
   dataSet,

--- a/src/pages/dataset/index.js
+++ b/src/pages/dataset/index.js
@@ -136,7 +136,6 @@ let DownloadDataSetButtonModal = ({
                 </p>
               </div>
             )}
-
             <div className="flex-row mb-1">
               <AggreationOptions />
             </div>

--- a/src/pages/download/DownloadBar.js
+++ b/src/pages/download/DownloadBar.js
@@ -28,13 +28,10 @@ let DownloadBar = ({ dataSet, push, editDataSet }) => {
     </div>
   );
 };
-DownloadBar = connect(
-  null,
-  {
-    editDataSet,
-    push,
-  }
-)(DownloadBar);
+DownloadBar = connect(null, {
+  editDataSet,
+  push,
+})(DownloadBar);
 export default DownloadBar;
 
 export function ShareDatasetButton({ dataSet: { id: dataSetId } }) {

--- a/src/pages/download/DownloadBar.scss
+++ b/src/pages/download/DownloadBar.scss
@@ -44,6 +44,12 @@
     padding-bottom: 1rem;
     flex-direction: column;
     margin-bottom: 2rem;
+
+    &__share-download {
+      > button:last-child {
+        margin-left: 16px;
+      }
+    }
   }
 
   &__actions {

--- a/src/pages/download/index.js
+++ b/src/pages/download/index.js
@@ -34,12 +34,9 @@ let Download = ({ download, fetchDataSetDetails }) => {
     </div>
   );
 };
-Download = connect(
-  ({ download }) => ({ download }),
-  {
-    fetchDataSetDetails,
-  }
-)(Download);
+Download = connect(({ download }) => ({ download }), {
+  fetchDataSetDetails,
+})(Download);
 export default Download;
 
 function DownloadEmpty() {


### PR DESCRIPTION
## Issue Number

#946 

## Purpose/Implementation Notes

* adds a download button to dataset page
* only shown when not processed or being processed
* copies when link was shared with the share dataset component
* rewrites `DatasetLoader` and `DatasetPageHeader` as functional components
* hides regenerate options when download button is present on dataset page

Also worth mentioning these changes avoided using redux and used the components that were written for the experiment download button which is part of the effort to transition away from redux as well as modernizing some components that it uses.

* The start processing button is blue by default and not disabled but it will show an alert if the agree to terms are not selected.

## Types of changes

* [x] New feature (non-breaking change which adds functionality)

## Functional tests

n/a tested downloading

## Checklist

* [X] Lint and unit tests pass locally with my changes
* [X] I have added necessary documentation (if appropriate)

## Screenshots

### processed dataset page with no extra button
![Screen Shot 2021-07-30 at 5 03 01 PM](https://user-images.githubusercontent.com/1075609/127712219-d4951c88-c97a-46ae-b558-d88c49b00476.png)

### share page with clone dataset button "Download Dataset"
![Screen Shot 2021-07-30 at 5 02 52 PM](https://user-images.githubusercontent.com/1075609/127712308-9d5ce0ad-3e74-44b1-8b83-7931cb2b8219.png)

### dataset options are preselected from shared dataset
![Screen Shot 2021-07-30 at 5 17 28 PM](https://user-images.githubusercontent.com/1075609/127712406-a738d9c3-ea29-44c0-ab32-492d95cfff18.png)

