### PR TITLE
fix datasetPageHeader download button

### DIFF
--- a/src/pages/dataset/DataSetPageHeader.js
+++ b/src/pages/dataset/DataSetPageHeader.js
@@ -141,8 +141,8 @@ let DataSetReady = ({ dataSet, createToken, hasToken }) => {
       // if the current user doesn't has a valid token, we have to generate it
       // and request the dataset data again to get the `download_url`
       const token = await createToken();
-      const dataSet = await getDataSet(dataSet.id, token);
-      window.location.href = dataSet.download_url;
+      const { download_url: downloadUrl } = await getDataSet(dataSet.id, token);
+      window.location.href = downloadUrl;
     } else {
       // otherwise we should have gotten the download url when the original
       // data was requested


### PR DESCRIPTION
## Issue Number

n/a

## Purpose/Implementation Notes

This prevents redefining `dataSet` in the handler for the download button.
The linter should have caught this.

## Types of changes

* [x] Bugfix (non-breaking change which fixes an issue)

## Functional tests

n/a downloaded a dataset locally

## Checklist

* [x] Lint and unit tests pass locally with my changes

## Screenshots

n/a
